### PR TITLE
initial nix flake package

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ pip3 install -r requirements.txt
 
 ```
 
+### Nix flake installation
+
+For Nix users, the flake can be used to run hexstrike-ai with many of its dependencies:
+
+```
+nix --extra-experimental-features "flakes nix-command" run "github:0x4m4/hexstrike-ai"
+```
+
 ### Installation and Setting Up Guide for various AI Clients:
 
 #### Installation & Demo Video

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,152 @@
+{
+  "nodes": {
+    "autorecon-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1748368588,
+        "narHash": "sha256-4yerINhRHINL8oDjF0ES72QrO0DLK6C5Y0wJ913Nozg=",
+        "owner": "Tib3rius",
+        "repo": "AutoRecon",
+        "rev": "fd87c99abc5ef8534f6caba2f3b2309308f5e962",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Tib3rius",
+        "repo": "AutoRecon",
+        "type": "github"
+      }
+    },
+    "docker-bench-security-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729495566,
+        "narHash": "sha256-ZXPUckcwsq0DT7smgwSHMFqrmRZhTqxRrQtn88QVNgM=",
+        "owner": "docker",
+        "repo": "docker-bench-security",
+        "rev": "ff26d67f25be60fc2d82a01710ee14570b2cb9db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "docker",
+        "repo": "docker-bench-security",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1757034884,
+        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "paramspider-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693983277,
+        "narHash": "sha256-lCkzd07IiS8XhnJdXrrqPAw7wfrvXqFDH7l5447ns4w=",
+        "owner": "devanshbatham",
+        "repo": "ParamSpider",
+        "rev": "790eb91213419e9c4ddec2c91201d4be5399cb77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "devanshbatham",
+        "repo": "ParamSpider",
+        "rev": "790eb91213419e9c4ddec2c91201d4be5399cb77",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1757246327,
+        "narHash": "sha256-6pNlGhwOIMfhe/RLjHdpXveKS4FyLHvlGe+KtjDild4=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "8d77f342d66ad1601cdb9d97e9388b69f64d4c8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "autorecon-src": "autorecon-src",
+        "docker-bench-security-src": "docker-bench-security-src",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "paramspider-src": "paramspider-src",
+        "pyproject-nix": "pyproject-nix",
+        "scout-suite-src": "scout-suite-src"
+      }
+    },
+    "scout-suite-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715333097,
+        "narHash": "sha256-bSnmb1grm8aoRjvvuc30QKBjcKz8wxnDXMdzFMDkiDE=",
+        "owner": "nccgroup",
+        "repo": "ScoutSuite",
+        "rev": "7909f2fc6186063e5c9e7ddef8c4d7d1072c8f3d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nccgroup",
+        "repo": "ScoutSuite",
+        "rev": "7909f2fc6186063e5c9e7ddef8c4d7d1072c8f3d",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,242 @@
+{
+  description = "HexStrike AI Nix flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    pyproject-nix = {
+      url = "github:nix-community/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    autorecon-src = {
+      url = "github:Tib3rius/AutoRecon";
+      flake = false;
+    };
+    paramspider-src = {
+      url = "github:devanshbatham/ParamSpider/790eb91213419e9c4ddec2c91201d4be5399cb77";
+      flake = false;
+    };
+    scout-suite-src = {
+      url = "github:nccgroup/ScoutSuite/7909f2fc6186063e5c9e7ddef8c4d7d1072c8f3d";
+      flake = false;
+    };
+    docker-bench-security-src = {
+      url = "github:docker/docker-bench-security";
+      flake = false;
+    };
+  };
+
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-utils,
+      pyproject-nix,
+      autorecon-src,
+      paramspider-src,
+      scout-suite-src,
+      docker-bench-security-src,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        # webdriver-manager (in requirements.txt) in nixpkgs has a platforms definition that excludes darwin
+        # we drop this along with linux-specific tests with this overlay
+        overlayWebdriverManager = (final: prev: {
+          python3 = prev.python3.override {
+            packageOverrides = self: super: {
+              "webdriver-manager" =
+                super."webdriver-manager".overridePythonAttrs (old: {
+                  # Allow on macOS (remove the platforms restriction)
+                  meta = builtins.removeAttrs old.meta [ "platforms" ];
+
+                  # Skip tests and avoid test deps (prevents pybrowsers/mdfind path)
+                  doCheck = false;
+                  nativeCheckInputs = [ ];
+                  checkInputs = [ ];
+                  checkPhase = "true";
+                  pythonImportsCheck = [ ];
+                });
+            };
+          };
+
+          # expose the updated package set so anything using pkgs.python3Packages sees it
+          python3Packages = final.python3.pkgs;
+        });
+
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+          };
+          overlays = [ overlayWebdriverManager ];
+        };
+
+        python = pkgs.python3;
+        pythonPackages = pkgs.python3Packages;
+
+        # Below are dependencies not packaged in nixpkgs
+        #autorecon-project = pyproject-nix.lib.project.loadPyproject { projectRoot = autorecon-src; };
+        #ar-attrs = autorecon-project.renderers.buildPythonPackage { inherit python; };
+        #autorecon = python.pkgs.buildPythonApplication (ar-attrs // {
+        #  name = "autorecon";
+        #});
+
+        #paramspider = python.pkgs.buildPythonApplication {
+        #  name = "paramspider";
+        #  version = "790eb91";
+
+        #  src = paramspider-src;
+        #};
+
+        #scout-suite = python.pkgs.buildPythonApplication {
+        #  name = "scout-suite";
+        #  version = "7909f2f";
+
+        #  src = scout-suite-src;
+        #};
+
+        docker-bench-security = pkgs.stdenv.mkDerivation {
+          name = "docker-bench-security";
+          builder = pkgs.bash;
+          buildInputs = [ pkgs.jq ];
+          args = let
+            buildScript = pkgs.writeShellScript "build" ''
+              ${pkgs.coreutils}/bin/mkdir -p $out/bin
+              ${pkgs.coreutils}/bin/cp ${docker-bench-security-src}/docker-bench-security.sh $out/bin/docker-bench-security.sh
+            '';
+          in [ buildScript ];
+        };
+        # End of custom packages
+
+        corepkgs = with pkgs; [
+          # Network & Reconnaissance
+          nmap
+          masscan
+          rustscan
+          amass
+          subfinder
+          nuclei
+          fierce
+          dnsenum
+          aircrack-ng
+          metasploit
+          #autorecon # TODO
+          responder
+          enum4linux-ng
+          theharvester
+          # Web Application Security
+          gobuster
+          feroxbuster
+          pythonPackages.dirsearch
+          ffuf
+          dirb
+          httpx
+          katana
+          nikto
+          sqlmap
+          wpscan
+          arjun
+          ##paramspider # TODO
+          dalfox
+          wafw00f
+          # Password & Authentication
+          john
+          hashcat
+          medusa
+          ##pythonPackages.patator # TODO: marked broken in nixpkgs
+          evil-winrm
+          hash-identifier
+          # Binary Analysis & Reverse Engineering
+          gdb
+          radare2
+          binwalk
+          ghidra-bin
+          binutils
+          volatility3
+          foremost
+          steghide
+          exiftool
+          # Cloud Security Tools
+          ##prowler # TODO broken in nixpkgs
+          trivy
+          ##scout-suite # TODO
+          kube-hunter
+          kube-bench
+          docker-bench-security
+        ] ++ lib.optionals pkgs.stdenv.isLinux [
+          # Linux specific tooling
+          # Network & Reconnaissance
+          netexec
+          # Web Application Security
+          # Password & Authentication
+          hydra
+          ophcrack
+          # Binary Analysis & Reverse Engineering
+          checksec
+          u-root-cmds
+          # Browser Agent Requirements
+          chromium
+          chromedriver
+        ] ++ lib.optionals pkgs.stdenv.isDarwin [
+          # macOS specific tooling
+          # Browser Agent Requirements
+          google-chrome
+        ];
+
+        hexstrike-ai-project = pyproject-nix.lib.project.loadRequirementsTxt {
+          projectRoot = ./.;
+        };
+        hexstrike-attrs = hexstrike-ai-project.renderers.buildPythonPackage { inherit python; };
+        hexstrike-ai-server-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
+          name = "hexstrike-ai-server";
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/bin
+            cp ${self}/hexstrike_server.py $out/bin/hexstrike_server.py
+            chmod +x $out/bin/hexstrike_server.py
+
+            wrapProgram $out/bin/hexstrike_server.py \
+              --prefix PATH : ${pkgs.lib.makeBinPath corepkgs}
+
+            runHook postInstall
+          '';
+          meta = {
+            mainProgram = "hexstrike_server.py";
+          };
+        });
+
+        hexstrike-ai-mcp-pkg = python.pkgs.buildPythonApplication (hexstrike-attrs // {
+          name = "hexstrike-ai-mcp";
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/bin
+            cp ${self}/hexstrike_mcp.py $out/bin/hexstrike_mcp.py
+            chmod +x $out/bin/hexstrike_mcp.py
+            runHook postInstall
+          '';
+          meta = {
+            mainProgram = "hexstrike_mcp.py";
+          };
+        });
+
+      in
+      {
+        devShell = pkgs.mkShell {
+          name = "HexStrike AI Dev Shell";
+          buildInputs = [ hexstrike-ai-server-pkg hexstrike-ai-mcp-pkg ];
+        };
+
+        packages = rec {
+          hexstrike-ai-server = hexstrike-ai-server-pkg;
+          hexstrike-ai-mcp = hexstrike-ai-mcp-pkg;
+          default = hexstrike-ai-server;
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+with open('requirements.txt') as f:
+    install_requires = f.read().splitlines()
+
+setup(
+  name='hexstrike-ai',
+  version='0.1.0',
+  author='0x4m4',
+  scripts=[
+    'hexstrike_server.py',
+    'hexstrike_mcp.py',
+  ],
+)
+


### PR DESCRIPTION
This packages hexstrike-ai as a Nix flake, making it trivial to run hexstrike with many of its dependencies that are packaged in nixpkgs.

For example, it can be run like so with my fork (i.e. in an environment without any of the recommended dependencies installed):

```
﻿nix run "github:heywoodlh/hexstrike-ai/nix-flake-init"
```

And in a separate shell, observe that the dependencies are available to the server:

```
curl --silent http://localhost:8888/health | jq '.' | grep true | tail -20
    "masscan": true,
    "medusa": true,
    "nikto": true,
    "nmap": true,
    "nuclei": true,
    "nxc": true,
    "objdump": true,
    "ophcrack": true,
    "radare2": true,
    "responder": true,
    "rustscan": true,
    "sqlmap": true,
    "steghide": true,
    "strings": true,
    "subfinder": true,
    "tcpdump": true,
    "trivy": true,
    "vol": true,
    "wafw00f": true,
    "wpscan": true,
```