### PR TITLE
Dockerize HexStrike AI and harden MCP flows for Claude and Codex automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+hexstrike-env/
+__pycache__/
+.vscode/
+*.log
+data/

--- a/README.md
+++ b/README.md
@@ -126,6 +126,87 @@ source hexstrike-env/bin/activate  # Linux/Mac
 pip3 install -r requirements.txt
 
 ```
+Ecco la versione corretta (inglese, struttura invariata):
+
+````markdown
+### 🐳 Docker Installation
+
+**Quick start**  
+*Note:* The helper scripts use `sudo`, and the container runs in `privileged` mode to ensure access to required capabilities (for example, the raw socket capability used by pentesting tools). You can harden the container based on your requirements, but additional checks are needed. See `docker-compose.yml` for capability details.
+
+Rationale:
+- Use the latest stable release of Kali Linux.
+- Install the latest tools using official methods (apt, official GitHub releases; compile only when necessary).
+- Provide a consistent, prebuilt, preconfigured, and reproducible environment that includes all required tools.
+
+```bash
+# 1) Clone the repository
+git clone https://github.com/0x4m4/hexstrike-ai.git
+cd hexstrike-ai
+chmod +x ./docker/*.sh
+
+# 2) Build the Docker image
+./docker/build-docker-image.sh
+
+# 3) Start the MCP server (host networking, privileged, caches persisted)
+./docker/start-docker-mcp-server.sh
+````
+
+**Verify installation**
+
+```bash
+# Health endpoint
+curl http://localhost:8888/health
+```
+
+### Update tool caches and databases
+
+The server starts immediately; a one-time background warmup runs automatically.
+To refresh caches explicitly (for example, before a batch of scans):
+
+```bash
+# Docker
+docker compose -f docker/docker-compose.yml exec hexstrike-mcp-server \
+  /usr/local/bin/update-tools-databases.sh
+```
+
+#### What gets updated
+
+* WPScan vulnerability database
+* Trivy database
+* Nuclei templates
+* ExploitDB (searchsploit)
+* Nikto signatures
+* Nmap NSE script database (`script.db`)
+* OWASP ZAP add-ons
+
+#### Where data is persisted (host → container)
+
+* `./data/trivy` → `/root/.cache/trivy`
+* `./data/wpscan` → `/root/.wpscan/db`
+* `./data/nuclei-templates` → `/root/nuclei-templates`
+* `./data/amass` → `/root/.config/amass`
+* `./data/msf` → `/root/.msf4`
+* `./data/exploitdb` → `/usr/share/exploitdb`
+* `./data/nikto` → `/var/lib/nikto`
+* `./data/zap` → `/root/.ZAP`
+* `./data/postgres` → `/var/lib/postgresql` (used by Clair and optional Metasploit databases)
+
+## Appendix: kube-bench - Host socket enablement (Docker/Podman)
+
+`kube-bench` needs a Docker-compatible API socket available inside the container at `/var/run/docker.sock`.
+`docker-compose.yml` already mounts the socket. If you use Docker Engine, nothing else to do. If you use Podman, enable the socket:
+
+```bash
+sudo systemctl enable --now podman.socket
+```
+
+Test inside the container:
+
+```bash
+sudo docker exec -it hexstrike-mcp-server bash
+docker ps
+```
 
 ### Installation and Setting Up Guide for various AI Clients:
 
@@ -254,7 +335,16 @@ Configure VS Code settings in `.vscode/settings.json`:
   "inputs": []
 }
 ```
-
+### VS Code ChatGPT Codex Integration
+Configure Codex settings in `~/.codex/config.toml`
+```yaml
+[mcp_servers.hexstrike-ai]
+command = "python3"
+args = ["-X","utf8",
+  "/path/to/hexstrike-ai/hexstrike_mcp.py",
+  "--server","http://127.0.0.1:8888"
+]
+```
 ---
 
 ## Features

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,60 @@
+# ==============================================================================
+# HexStrike - Example environment overrides
+# ==============================================================================
+# Copy this file to ".env" (same folder as docker-compose.yml) and adjust values.
+# All variables are optional; docker-compose provides sane defaults.
+# Do NOT commit real secrets.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# MCP server runtime
+# ------------------------------------------------------------------------------
+# TCP port where the MCP HTTP server listens (container uses host networking).
+# Default inside compose: 8888
+# MCP_PORT=8888
+
+# Global command timeout (seconds) for long-running tools.
+# Default inside compose: 3600
+# COMMAND_TIMEOUT=3600
+
+# Enable extra logging from the app (off by default).
+# DEBUG_MODE=true
+
+
+# ------------------------------------------------------------------------------
+# Clair API endpoint (used by clairctl and by the MCP server)
+# ------------------------------------------------------------------------------
+# Default: local Clair bound on 127.0.0.1:8080 (both services run with host networking).
+# Keep this as-is if you use the bundled Clair + Postgres services.
+# CLAIR_ADDR=http://127.0.0.1:8080
+
+# Example: use an external Clair instance instead of the bundled service.
+# If you set this, you should disable the 'hexstrike-clair' service in compose.
+# CLAIR_ADDR=http://clair.example.org:8080
+
+
+# ------------------------------------------------------------------------------
+# Metasploit database (optional)
+# ------------------------------------------------------------------------------
+# If set, the MCP container will bootstrap Metasploit to use this DB (idempotent).
+# Leave empty to keep Metasploit in file-based/offline mode.
+# Format: postgresql://USER:PASS@HOST:PORT/DBNAME
+# Example with the bundled Postgres (if you created the 'msf' user/db on host):
+# MSF_DB_URL=postgresql://msf:msf@127.0.0.1:5432/msf
+# Otherwise, point to your external DB:
+# MSF_DB_URL=postgresql://msf:VerySecret@db.example.org:5432/msf
+
+
+# ------------------------------------------------------------------------------
+# (Informational) External Postgres for Clair — ONLY if you customize clair-config.yaml
+# ------------------------------------------------------------------------------
+# Clair’s DB connection is read from docker/config/clair-config.yaml, not from env.
+# If you want Clair to use an external Postgres, edit that YAML accordingly.
+# The variables below are provided purely as documentation/convenience and are
+# NOT automatically consumed unless you template the config yourself.
+# PGHOST=db.example.org
+# PGPORT=5432
+# PGUSER=clair
+# PGPASSWORD=change-me
+# PGDATABASE=clair
+# SSLMODE=disable

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,842 @@
+# ==============================================================================
+# HexStrike AI MCP Server v6.0 - Docker Image (Multi-stage Build)
+# ==============================================================================
+# Repository: https://github.com/0x4m4/hexstrike-ai
+# License: MIT
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Stage A: Python 3.12 base (for Prowler and Pacu)
+# ------------------------------------------------------------------------------
+FROM docker.io/python:3.12-slim AS python312-base
+
+# ------------------------------------------------------------------------------
+# Stage B: CloudMapper builder (Python 3.10 + dedicated venv with pyjq)
+# ------------------------------------------------------------------------------
+FROM docker.io/python:3.10-slim AS cloudmapper-builder
+
+ENV CM_VENV=/opt/venvs/cloudmapper
+WORKDIR /opt/hexstrike
+
+# Install build prerequisites and jq development libraries for pyjq
+RUN set -euo pipefail; \
+    apt-get update && apt-get install -y --no-install-recommends \
+      build-essential autoconf automake libtool pkg-config \
+      git curl ca-certificates \
+      libjq-dev libonig-dev bison flex \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a dedicated virtual environment for CloudMapper
+RUN python -m venv "$CM_VENV" \
+ && "$CM_VENV/bin/pip" install --no-cache-dir -U pip setuptools wheel
+
+# Fetch CloudMapper directly from upstream to avoid context COPY issues
+RUN git clone --depth 1 https://github.com/duo-labs/cloudmapper.git /opt/hexstrike/tools/cloudmapper \
+ && rm -rf /opt/hexstrike/tools/cloudmapper/.git
+
+# Normalize requirement pins and install into the dedicated venv
+RUN REQ=/opt/hexstrike/tools/cloudmapper/requirements.txt; \
+  # Align matplotlib/numpy to versions compatible with Python 3.10
+  sed -i \
+    -e 's/^matplotlib==3\.4\.3$/matplotlib==3\.7\.5/' \
+    -e 's/^numpy==1\.22\.0$/numpy>=1\.23/' \
+    "$REQ"; \
+  # Drop typed-ast (not supported on Python ≥ 3.10)
+  sed -i '/^typed-ast==/d' "$REQ"; \
+  # Optionally bump pyjq to a newer compatible version if pinned
+  sed -i 's/^pyjq==2\.4\.0$/pyjq==2\.6\.0/' "$REQ"; \
+  # Install all dependencies in the CloudMapper venv
+  "$CM_VENV/bin/pip" install --no-cache-dir --prefer-binary -r "$REQ"
+
+# ------------------------------------------------------------------------------
+# Stage C: Node.js 18 builder for insomnia-inso (isolated runtime)
+# ------------------------------------------------------------------------------
+FROM docker.io/node:18-bullseye AS insomnia-node18-builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    NPM_CONFIG_PREFIX=/opt/insomnia
+
+RUN set -eu; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+        libcurl4-openssl-dev \
+        pkg-config \
+        git \
+        jq \
+    && python3 -m pip install --no-cache-dir gyp-next
+
+# Install insomnia CLI plus supporting reconnaissance tools (official releases)
+RUN npm install -g --build-from-source insomnia-inso \
+    && npm cache clean --force
+
+RUN mkdir -p /opt/insomnia-artifacts/node18 && \
+    cp -a /usr/local/bin /opt/insomnia-artifacts/node18/bin && \
+    cp -a /usr/local/lib /opt/insomnia-artifacts/node18/lib && \
+    cp -a /usr/local/include /opt/insomnia-artifacts/node18/include && \
+    cp -a /usr/local/share /opt/insomnia-artifacts/node18/share && \
+    cp -a /opt/insomnia /opt/insomnia-artifacts/insomnia
+
+# ------------------------------------------------------------------------------
+# Stage D: Final - Kali Linux + All Tools & Runtimes
+# ------------------------------------------------------------------------------
+FROM docker.io/kalilinux/kali-last-release:latest
+
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /opt/hexstrike
+
+# Copy Python 3.12 runtime from Stage A (needed by Prowler and Pacu)
+COPY --from=python312-base /usr/local/ /usr/local/
+RUN ln -sf /usr/local/lib/libpython3.12.so.1.0 /usr/local/lib/libpython3.12.so && \
+    ldconfig
+
+# ==============================================================================
+# Phase 1: Base System Packages
+# ==============================================================================
+# - curl: data transfer utility for installers and health checks
+# - wget: alternative download utility
+# - git: distributed version control
+# - ca-certificates: TLS certificate bundle for secure downloads
+# - gnupg2: OpenPGP toolkit for repository keys
+# - lsb-release: distribution release information
+# - xz-utils: XZ compression utilities
+# - httpie: user-friendly HTTP client
+# - wordlists: common wordlists for security testing
+# - p7zip-full: 7-Zip archiver
+# - binutils: binary utilities
+RUN set -euo pipefail; \
+    apt-get update && apt-get install -y --no-install-recommends \
+        apt-utils \
+        curl \
+        wget \
+        git \
+        gnupg2 \
+        lsb-release \
+        xz-utils \
+        ca-certificates \
+        wordlists \
+        httpie \
+        jq \
+        unzip \
+        p7zip-full \
+        binutils \
+        vim \
+        nano
+
+# ==============================================================================
+# Phase 2: Language Runtimes and Build Tools
+# ==============================================================================
+# - node + npm: JavaScript runtime and package manager
+# - default-jdk: Java Development Kit
+# - ruby-full: Ruby language and standard toolchain
+# - pipx: isolated Python CLI installer
+RUN apt-get install -y --no-install-recommends \
+        nodejs \
+        npm \
+        default-jdk \
+        ruby-full \
+        pipx \
+        python3-venv \
+        python3-pip \
+        build-essential \
+        python3-dev \
+        g++
+
+ENV PIPX_DEFAULT_PYTHON=/usr/bin/python3
+ENV npm_config_python=/usr/bin/python3
+ENV PYTHON=/usr/bin/python3
+
+# ==============================================================================
+# Phase 3: Python Virtual Environment
+# ==============================================================================
+ENV VIRTUAL_ENV=/opt/hexstrike/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN /usr/bin/python3 -m venv "$VIRTUAL_ENV" \
+ && . "$VIRTUAL_ENV/bin/activate" \
+ && pip install --no-cache-dir --upgrade pip setuptools wheel
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_DEFAULT_TIMEOUT=120 \
+    PIP_NO_PYTHON_VERSION_WARNING=1
+ENV PATH="${PATH}:/root/.local/bin"
+
+
+# ==============================================================================
+# Phase 4: Cloud & Container Security (Python CLIs)
+# ==============================================================================
+# - ansible: automation engine for configuration and orchestration
+RUN apt-get install -y --no-install-recommends \
+        ansible
+
+# Install Python CLIs via pipx (official, isolated)
+# - checkov: IaC security scanner for Terraform/CloudFormation/Kubernetes
+# - prowler: multi-cloud security assessment and compliance checks
+# - ScoutSuite: multi-cloud security auditing (AWS/Azure/GCP/Alibaba Cloud)
+# - kube-hunter: Kubernetes penetration testing (active/passive)
+# - shodan: official Shodan CLI
+# - censys: official Censys CLI
+RUN pipx install --pip-args="--no-cache-dir --prefer-binary" checkov     && \
+    pipx install --python /usr/local/bin/python3.12 --pip-args="--no-cache-dir --prefer-binary" prowler     && \
+    pipx install --pip-args="--no-cache-dir --prefer-binary" ScoutSuite  && \
+    pipx install --pip-args="--no-cache-dir --prefer-binary" kube-hunter && \
+    pipx install --pip-args="--no-cache-dir --prefer-binary" shodan      && \
+    pipx install --pip-args="--no-cache-dir --prefer-binary" censys
+
+# - terrascan: policy-as-code scanner for IaC
+RUN url="$(curl -s https://api.github.com/repos/tenable/terrascan/releases/latest \
+      | awk -F'"' '/browser_download_url/ && /Linux_[xX]86_64\.tar\.gz/ {print $4; exit}')"; \
+    curl -fsSL "$url" -o /tmp/terrascan.tgz; \
+    tar -C /tmp -xzf /tmp/terrascan.tgz terrascan; \
+    install /tmp/terrascan /usr/local/bin/terrascan; \
+    rm -f /tmp/terrascan /tmp/terrascan.tgz
+
+# - OpenTofu: Terraform-compatible IaC tool (APT repository)
+RUN install -d -m 0755 /etc/apt/keyrings && \
+    curl -fsSL https://get.opentofu.org/opentofu.gpg | tee /etc/apt/keyrings/opentofu.gpg >/dev/null && \
+    curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu-repo.gpg && \
+    chmod a+r /etc/apt/keyrings/opentofu.gpg /etc/apt/keyrings/opentofu-repo.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" > /etc/apt/sources.list.d/opentofu.list && \
+    echo "deb-src [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" >> /etc/apt/sources.list.d/opentofu.list && \
+    apt-get update && apt-get install -y --no-install-recommends tofu && \
+    ln -sf /usr/bin/tofu /usr/local/bin/terraform
+
+# AWS CLI v2 official
+RUN cd /tmp && \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip && \
+    unzip -q awscliv2.zip && ./aws/install && \
+    rm -rf /tmp/aws /tmp/awscliv2.zip
+
+# ==============================================================================
+# Phase 5: Network & Reconnaissance Tools
+# ==============================================================================
+# - nmap: network exploration and security auditing
+# - masscan: high-speed port scanner
+# - autorecon: automated network reconnaissance
+# - amass: in-depth attack surface mapping and asset discovery
+# - subfinder: passive subdomain enumeration
+# - sublist3r: fast subdomain enumeration
+# - fierce: DNS reconnaissance
+# - dnsenum: DNS enumeration
+# - dnsrecon: DNS reconnaissance
+# - theharvester: OSINT for emails, hosts, and subdomains
+# - whois: domain registration query client
+# - dnsutils: DNS utilities (dig, nslookup, etc.)
+# - bind9-host: DNS lookup utility
+# - responder: LLMNR, NBT-NS, and MDNS poisoner
+# - netexec: network authentication and execution toolkit
+# - enum4linux: Windows/Samba enumeration
+# - enum4linux-ng: Windows/Samba enumeration (next-gen)
+# - nbtscan: NetBIOS name scanner
+# - arp-scan: ARP network scanner
+# - samba-common-bin: Samba client utilities
+# - smbclient: SMB/CIFS client
+# - iproute2: provides `ip` (route/addr) used by wrappers
+# - iputils-ping: ICMP ping
+# - net-tools: legacy ifconfig/netstat (diagnostics)
+# - ethtool: NIC/link diagnostics
+# - traceroute: routing diagnostics
+RUN apt-get install -y --no-install-recommends \
+        nmap \
+        masscan \
+        autorecon \
+        amass \
+        subfinder \
+        sublist3r \
+        fierce \
+        dnsenum \
+        dnsrecon \
+        theharvester \
+        whois \
+        dnsutils \
+        bind9-host \
+        responder \
+        netexec \
+        enum4linux \
+        enum4linux-ng \
+        nbtscan \
+        arp-scan \
+        samba-common-bin \
+        smbclient \
+        iproute2 \
+        iputils-ping \
+        net-tools \
+        ethtool \
+        traceroute
+
+# - rustscan: modern and fast port scanner
+RUN tmp="$(mktemp -d)"; cd "$tmp"; \
+  url="$(curl -fsSL https://api.github.com/repos/bee-san/RustScan/releases/latest \
+         | jq -r '.assets[]?.browser_download_url | select(endswith("rustscan.deb.zip"))' | head -n1)"; \
+  [ -n "$url" ] || { echo "rustscan.deb.zip asset not found in latest release"; exit 1; }; \
+  curl -fsSL -o rustscan.deb.zip "$url"; \
+  unzip -q rustscan.deb.zip; \
+  deb="$(printf '%s\n' rustscan*.deb | head -n1)"; \
+  dpkg -i "$deb" || apt-get -f install -y --no-install-recommends; \
+  cd /; rm -rf "$tmp"
+
+# ==============================================================================
+# Phase 6: Web Application Security Tools
+# ==============================================================================
+# - gobuster: directory and DNS enumeration
+# - feroxbuster: recursive content discovery
+# - ffuf: fast web fuzzer
+# - dotdotpwn: path traversal fuzzer
+# - xsser: cross-site scripting framework
+# - wfuzz: web application fuzzer
+# - dirb: web content scanner
+# - dirsearch: web path scanner
+# - nikto: web server scanner
+# - sqlmap: automated SQL injection tool
+# - wpscan: WordPress security scanner
+# - arjun: HTTP parameter discovery
+# - paramspider: parameter miner
+# - hakrawler: web endpoint crawler
+# - wafw00f: WAF fingerprinting
+# - whatweb: web technology fingerprinting
+# - burpsuite: web security testing platform
+# - zaproxy: OWASP ZAP scanner
+RUN apt-get install -y --no-install-recommends \
+        seclists \
+        gobuster \
+        feroxbuster \
+        ffuf \
+        dotdotpwn \
+        xsser \
+        wfuzz \
+        dirb \
+        dirsearch \
+        nikto \
+        sqlmap \
+        wpscan \
+        arjun \
+        paramspider \
+        hakrawler \
+        wafw00f \
+        whatweb \
+        burpsuite \
+        zaproxy
+
+# dirsearch requirements
+# - python3-requests-ntlm: NTLM authentication
+# - defusedxml: XML bomb protection for Python stdlib modules
+# - colorama: cross-platform terminal colors
+RUN python3 -m pip install --no-cache-dir requests-ntlm defusedxml colorama
+
+# - katana: next-generation web crawler and spider
+RUN set -euo pipefail; \
+  tmp="$(mktemp -d)"; cd "$tmp"; \
+  j="$(curl -fsSL https://api.github.com/repos/projectdiscovery/katana/releases/latest)"; \
+  tag="$(printf '%s' "$j" | jq -r '.tag_name')"; \
+  asset="$(printf '%s' "$j" | jq -r '.assets[]?.name | select(test("^katana_[0-9.]+_linux_amd64\\.zip$"))' | head -n1)"; \
+  [ -n "$asset" ] || { echo 'katana: linux_amd64 zip asset not found'; exit 1; }; \
+  curl -fsSL -o "$asset" "https://github.com/projectdiscovery/katana/releases/download/${tag}/${asset}"; \
+  unzip -p "$asset" "*/katana" > katana 2>/dev/null || unzip -p "$asset" "katana" > katana; \
+  chmod 0755 katana; install -m 0755 katana /usr/local/bin/katana; \
+  cd /; rm -rf "$tmp"
+
+# - httpx: fast HTTP probing with technology detection
+RUN set -euo pipefail; \
+  tmp="$(mktemp -d)"; cd "$tmp"; \
+  j="$(curl -fsSL https://api.github.com/repos/projectdiscovery/httpx/releases/latest)"; \
+  tag="$(printf '%s' "$j" | jq -r '.tag_name')"; \
+  asset="$(printf '%s' "$j" | jq -r '.assets[]?.name | select(test("^httpx_[0-9.]+_linux_amd64\\.zip$"))' | head -n1)"; \
+  [ -n "$asset" ] || { echo 'httpx: linux_amd64 zip asset not found'; exit 1; }; \
+  curl -fsSL -o "$asset" "https://github.com/projectdiscovery/httpx/releases/download/${tag}/${asset}"; \
+  unzip -p "$asset" "*/httpx" > httpx 2>/dev/null || unzip -p "$asset" "httpx" > httpx; \
+  chmod 0755 httpx; install -m 0755 httpx /usr/local/bin/httpx; \
+  cd /; rm -rf "$tmp"
+
+# - nuclei: template-driven vulnerability scanner
+RUN set -euo pipefail; \
+  tmp="$(mktemp -d)"; cd "$tmp"; \
+  j="$(curl -fsSL https://api.github.com/repos/projectdiscovery/nuclei/releases/latest)"; \
+  tag="$(printf '%s' "$j" | jq -r '.tag_name')"; \
+  asset="$(printf '%s' "$j" | jq -r '.assets[]?.name | select(test("^nuclei_[0-9.]+_linux_amd64\\.zip$"))' | head -n1)"; \
+  [ -n "$asset" ] || { echo 'nuclei: linux_amd64 zip asset not found'; exit 1; }; \
+  curl -fsSL -o "$asset" "https://github.com/projectdiscovery/nuclei/releases/download/${tag}/${asset}"; \
+  unzip -p "$asset" "*/nuclei" > nuclei 2>/dev/null || unzip -p "$asset" "nuclei" > nuclei; \
+  chmod 0755 nuclei; install -m 0755 nuclei /usr/local/bin/nuclei; \
+  cd /; rm -rf "$tmp"
+
+# - dalfox: fast XSS scanner
+RUN set -euo pipefail; \
+  tmp="$(mktemp -d)"; cd "$tmp"; \
+  j="$(curl -fsSL https://api.github.com/repos/hahwul/dalfox/releases/latest)"; \
+  tag="$(printf '%s' "$j" | jq -r '.tag_name')"; \
+  [ -n "$tag" ]; \
+  asset="dalfox-linux-amd64.tar.gz"; \
+  curl -fsSL -o "$asset" "https://github.com/hahwul/dalfox/releases/download/${tag}/${asset}"; \
+  tar -xOzf "$asset" dalfox-linux-amd64 > dalfox; \
+  install -m 0755 dalfox /usr/local/bin/dalfox; \
+  cd /; rm -rf "$tmp"
+
+# - jaeles: signature-based web vulnerability scanner
+RUN set -euo pipefail; \
+  tmp="$(mktemp -d)"; cd "$tmp"; \
+  j="$(curl -fsSL https://api.github.com/repos/jaeles-project/jaeles/releases/latest)"; \
+  tag="$(printf '%s' "$j" | jq -r '.tag_name')"; \
+  asset="$(printf '%s' "$j" | jq -r '.assets[]?.name | select(test("^jaeles-.*-linux\\.zip$"))' | head -n1)"; \
+  [ -n "$asset" ] || { echo 'jaeles: linux zip asset not found'; exit 1; }; \
+  curl -fsSL -o "$asset" "https://github.com/jaeles-project/jaeles/releases/download/${tag}/${asset}"; \
+  unzip -p "$asset" "*/jaeles" > jaeles 2>/dev/null || unzip -p "$asset" "jaeles" > jaeles; \
+  chmod 0755 jaeles; install -m 0755 jaeles /usr/local/bin/jaeles; \
+  cd /; rm -rf "$tmp"
+
+# - x8: fast XSS scanner
+RUN set -euo pipefail; \
+  tmp="$(mktemp -d)"; cd "$tmp"; \
+  j="$(curl -fsSL https://api.github.com/repos/Sh1Yo/x8/releases/latest)"; \
+  tag="$(printf '%s' "$j" | jq -r '.tag_name')"; \
+  asset="$(printf '%s' "$j" | jq -r '.assets[]?.name | select(. == "x86_64-linux-x8.gz")' | head -n1)"; \
+  [ -n "$asset" ] || { echo 'x8: x86_64-linux-x8.gz not found'; exit 1; }; \
+  curl -fsSL -o "$asset" "https://github.com/Sh1Yo/x8/releases/download/${tag}/${asset}"; \
+  gzip -dc "$asset" > x8; \
+  chmod 0755 x8; install -m 0755 x8 /usr/local/bin/x8; \
+  cd /; rm -rf "$tmp"
+
+# - gau: URL discovery from AlienVault, Wayback Machine, Common Crawl, and URLScan.io
+RUN set -euo pipefail; \
+  tmp="$(mktemp -d)"; cd "$tmp"; \
+  j="$(curl -fsSL https://api.github.com/repos/lc/gau/releases/latest)"; \
+  tag="$(printf '%s' "$j" | jq -r '.tag_name')"; \
+  asset="$(printf '%s' "$j" | jq -r '.assets[]?.name | select(test("^gau_[0-9.]+_linux_amd64\\.tar\\.gz$"))' | head -n1)"; \
+  [ -n "$asset" ] || { echo 'gau: linux_amd64 tar.gz asset not found'; exit 1; }; \
+  curl -fsSL -o "$asset" "https://github.com/lc/gau/releases/download/${tag}/${asset}"; \
+  tar -xOzf "$asset" gau > gau; \
+  install -m 0755 gau /usr/local/bin/gau; \
+  cd /; rm -rf "$tmp"
+
+
+# ==============================================================================
+# Phase 7: Authentication & Password Security
+# ==============================================================================
+# - hydra: network login cracker
+# - john: password cracker
+# - hashcat: gpu-accelerated password recovery
+# - medusa: parallel brute-forcer
+# - patator: multi-purpose brute-forcer
+# - evil-winrm: WinRM shell for Windows
+# - hash-identifier: hash type identifier
+# - hashid: hash algorithm identifier
+# - ophcrack: Windows password cracker
+# - hashcat-utils: companion utilities for hashcat
+RUN apt-get install -y --no-install-recommends \
+        hydra \
+        john \
+        hashcat \
+        medusa \
+        patator \
+        evil-winrm \
+        hash-identifier \
+        hashid \
+        ophcrack \
+        hashcat-utils
+
+# ==============================================================================
+# Phase 8: Binary & Forensics Tools
+# ==============================================================================
+# - gdb: GNU debugger
+# - radare2: reverse engineering framework
+# - ghidra: software reverse engineering suite
+# - binwalk: firmware analysis tool
+# - checksec: binary security checks
+# - foremost: file carving utility
+# - steghide: steganography tool
+# - exiftool: metadata extraction
+# - ropper: ROP gadget finder
+# - autopsy: digital forensics platform
+# - sleuthkit: digital forensics toolkit
+# - outguess: steganography analysis
+# - testdisk: data recovery utility
+# - scalpel: file carving utility
+# - bulk-extractor: bulk data extractor for forensics
+# - smbmap: SMB share enumerator
+# - zbar-tools: barcode and QR decoding
+# - apktool: Android APK analysis
+# - android-tools-adb: Android Debug Bridge
+# - xxd: hex dump utility
+RUN apt-get install -y --no-install-recommends \
+        gdb \
+        radare2 \
+        ghidra \
+        binwalk \
+        checksec \
+        foremost \
+        steghide \
+        exiftool \
+        ropper \
+        autopsy \
+        sleuthkit \
+        outguess \
+        testdisk \
+        scalpel \
+        bulk-extractor \
+        smbmap \
+        zbar-tools \
+        apktool \
+        android-tools-adb \
+        xxd
+
+# - ropgadget: ROP/JOP gadget finder
+# - volatility3: memory forensics framework
+# - uro: URL deduplication and normalization
+# - pwntools: CTF and exploit development library
+RUN pip install --no-cache-dir \
+        ropgadget \
+        volatility3 \
+        uro \
+        pwntools
+
+# pwninit: CTF binary setup automation
+RUN tmp="$(mktemp -d)"; cd "$tmp"; \
+  json="$(curl -fsSL https://api.github.com/repos/io12/pwninit/releases/latest)"; \
+  url="$(printf '%s\n' "$json" | jq -r '.assets[]?.browser_download_url' | grep -E '/pwninit($|[^/]*$)' | head -n1)"; \
+  [ -n "$url" ] || { echo "No binary asset for pwninit latest"; exit 1; }; \
+  curl -fsSL -o pwninit "$url"; \
+  chmod +x pwninit; install -m 0755 pwninit /usr/local/bin/pwninit; \
+  cd /; rm -rf "$tmp"
+
+# - zsteg: PNG/BMP steganography detection
+# - one_gadget: ROP gadget finder for glibc
+RUN gem install --no-document zsteg one_gadget
+
+# - hashpump: length extension attack helper (via hashpumpy CLI wrapper)
+RUN pip install --no-cache-dir hashpumpy && \
+    printf '%s\n' '#!/usr/bin/env python3' \
+'import argparse' \
+'from hashpumpy import hashpump' \
+'parser = argparse.ArgumentParser()' \
+'parser.add_argument("-s","--signature", required=True)' \
+'parser.add_argument("-d","--data", required=True)' \
+'parser.add_argument("-k","--key_length", type=int, required=True)' \
+'parser.add_argument("-a","--append_data", required=True)' \
+'args = parser.parse_args()' \
+'new_sig, new_msg = hashpump(args.signature, args.data, args.append_data, args.key_length)' \
+'print(new_sig)' \
+'print(new_msg)' \
+> /usr/local/bin/hashpump && chmod +x /usr/local/bin/hashpump
+
+# ==============================================================================
+# Phase 9: OSINT & Intelligence Tools
+# ==============================================================================
+# - exploitdb: exploit database search client
+# - kismet: wireless network detector and sniffer
+# - sherlock: username enumeration across sites
+# - recon-ng: web reconnaissance framework
+# - spiderfoot: automated OSINT platform
+# - maltego: graphical link analysis
+RUN apt-get install -y --no-install-recommends \
+        exploitdb \
+        kismet \
+        sherlock \
+        recon-ng \
+        spiderfoot \
+        maltego
+
+# OSINT companion CLIs via npm (Node.js LTS runtime)
+# - social-analyzer: social media analysis toolkit
+# - pwned: have i been pwned? CLI
+# - graphql-inspector: GraphQL diffing and audit utility
+# - jwt-cracker: JSON Web Token cracking utility
+# - graphql-playground-html: GraphQL playground HTML renderer
+# - graphql-voyager: GraphQL schema visualization
+# - newman: Postman CLI runner
+RUN npm install -g \
+        social-analyzer \
+        pwned \
+        graphql-inspector \
+        jwt-cracker \
+        graphql-playground-html \
+        graphql-voyager \
+        newman
+
+# GitHub releases for tomnomnom tools
+# - anew: append-only unique line filter
+# - qsreplace: query string replacement
+# - waybackurls: URL collection from Wayback Machine
+# - assetfinder: subdomain discovery
+RUN tmp="$(mktemp -d)"; cd "$tmp"; \
+  for repo in tomnomnom/anew tomnomnom/qsreplace tomnomnom/waybackurls; do \
+    name="${repo##*/}"; \
+    json="$(curl -fsSL "https://api.github.com/repos/${repo}/releases/latest")"; \
+    url="$(printf '%s' "$json" | jq -r '.assets[]?.browser_download_url' | grep -E -- '-linux-amd64($|.*\.(tgz|tar\.gz|zip)$)' | head -n1)"; \
+    [ -n "$url" ] || { echo "No linux-amd64 asset for ${repo} latest"; exit 1; }; \
+    file="${url##*/}"; curl -fsSL -o "$file" "$url"; \
+    case "$file" in \
+      *.tgz|*.tar.gz) tar -xzf "$file" ;; \
+      *.zip) unzip -q "$file" ;; \
+      *) : ;; \
+    esac; \
+    bin_path="$(find . -type f -perm -111 -name "${name}*" | head -n1)"; \
+    [ -n "$bin_path" ] || bin_path="./$name"; \
+    [ -f "$bin_path" ] || bin_path="$(find . -maxdepth 1 -type f -perm -111 | head -n1)"; \
+    [ -n "$bin_path" ] || { echo "No executable found for ${repo}"; exit 1; }; \
+    install -m 0755 "$bin_path" "/usr/local/bin/$name"; \
+    rm -rf ./*; \
+  done; \
+  # assetfinder: /releases/latest may return 404 → use /releases (first item)
+  repo="tomnomnom/assetfinder"; name="assetfinder"; \
+  json="$(curl -fsSL "https://api.github.com/repos/${repo}/releases")"; \
+  url="$(printf '%s' "$json" | jq -r '.[0].assets[]?.browser_download_url' | grep -E -- '-linux-amd64($|.*\.(tgz|tar\.gz|zip)$)' | head -n1)"; \
+  [ -n "$url" ] || { echo "No linux-amd64 asset for ${repo}"; exit 1; }; \
+  file="${url##*/}"; curl -fsSL -o "$file" "$url"; \
+  case "$file" in \
+    *.tgz|*.tar.gz) tar -xzf "$file" ;; \
+    *.zip) unzip -q "$file" ;; \
+    *) : ;; \
+  esac; \
+  bin_path="$(find . -type f -perm -111 -name "${name}*" | head -n1)"; \
+  [ -n "$bin_path" ] || bin_path="./$name"; \
+  [ -f "$bin_path" ] || bin_path="$(find . -maxdepth 1 -type f -perm -111 | head -n1)"; \
+  [ -n "$bin_path" ] || { echo "No executable found for ${repo}"; exit 1; }; \
+  install -m 0755 "$bin_path" "/usr/local/bin/$name"; \
+  cd /; rm -rf "$tmp"
+
+# Bundle isolated Node.js 18 runtime for insomnia-inso only
+COPY --from=insomnia-node18-builder /opt/insomnia-artifacts/node18 /opt/insomnia-node18
+COPY --from=insomnia-node18-builder /opt/insomnia-artifacts/insomnia /opt/insomnia
+
+# ==============================================================================
+# Phase 10: Wireless & Packet Analysis Tools
+# ==============================================================================
+# - wireshark: network protocol analyzer
+# - tshark: terminal Wireshark analyzer
+# - tcpdump: packet capture utility
+# - aircrack-ng: 802.11 WEP/WPA cracking suite
+RUN apt-get install -y --no-install-recommends \
+        wireshark \
+        tshark \
+        tcpdump \
+        aircrack-ng
+
+# ==============================================================================
+# Phase 11: Exploitation Frameworks
+# ==============================================================================
+# - metasploit-framework: penetration testing framework
+RUN apt-get install -y --no-install-recommends \
+        metasploit-framework
+
+# ==============================================================================
+# Phase 12: Runtime Security Agents
+# ==============================================================================
+# - falco: runtime threat detection for containers and hosts
+RUN install -d -m 0755 /usr/share/keyrings && \
+    curl -fsSL https://falco.org/repo/falcosecurity-packages.asc \
+      | gpg --dearmor -o /usr/share/keyrings/falco-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/falco-archive-keyring.gpg] https://download.falco.org/packages/deb stable main" \
+      > /etc/apt/sources.list.d/falcosecurity.list && \
+    apt-get update -y && \
+    mkdir -p /tmp/falco && cd /tmp/falco && \
+    apt-get download falco && \
+    dpkg-deb -x ./falco_*.deb / && \
+    cd / && rm -rf /tmp/falco
+
+# ==============================================================================
+# Phase 13: Browser Agent Requirements
+# ==============================================================================
+# - chromium: headless-capable browser
+# - chromium-driver: WebDriver for Chromium
+RUN apt-get install -y --no-install-recommends \
+      chromium \
+      chromium-driver
+
+# ==============================================================================
+# Phase 14: Security Tool Repositories & Wrappers
+# Bring CloudMapper code and its dedicated venv from the builder stage
+COPY --from=cloudmapper-builder /opt/venvs/cloudmapper /opt/venvs/cloudmapper
+COPY --from=cloudmapper-builder /opt/hexstrike/tools/cloudmapper /opt/hexstrike/tools/cloudmapper
+
+# Install system deps for Pacu (cffi may require libffi); then install Pacu via pipx on Python 3.12
+RUN apt-get install -y --no-install-recommends libffi-dev \
+ && pipx install --python /usr/local/bin/python3.12 git+https://github.com/RhinoSecurityLabs/pacu.git
+
+# Clone remaining tool repositories
+RUN mkdir -p /opt/hexstrike/tools && \
+    git clone --depth 1 https://github.com/ticarpi/jwt_tool.git /opt/hexstrike/tools/jwt_tool && \
+    rm -rf /opt/hexstrike/tools/jwt_tool/.git && \
+    git clone --depth 1 https://github.com/niklasb/libc-database.git /opt/hexstrike/tools/libc-database && \
+    rm -rf /opt/hexstrike/tools/libc-database/.git && \
+    git clone --depth 1 https://github.com/longld/peda.git /root/peda && \
+    rm -rf /root/peda/.git && \
+    mkdir -p /opt/stegsolve && \
+    curl -fsSL -o /opt/stegsolve/stegsolve.jar https://github.com/Giotino/stegsolve/releases/download/v1.4/StegSolve-1.4.jar && \
+    chmod 644 /opt/stegsolve/stegsolve.jar && \
+    ln -s /opt/hexstrike/tools/libc-database /opt/libc-database && \
+    ln -s /opt/hexstrike/tools/jwt_tool /opt/jwt_tool
+
+RUN pip install --no-cache-dir -r /opt/hexstrike/tools/jwt_tool/requirements.txt
+
+# ==============================================================================
+# Phase 15: Cloud & Container Security Binaries
+# ==============================================================================
+# - trivy: container image vulnerability scanner
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+  | sh -s -- -b /usr/local/bin
+
+# - docker-bench-security: Docker daemon configuration audit
+RUN mkdir -p /opt/hexstrike/tools && \
+    git clone --depth 1 https://github.com/docker/docker-bench-security.git /opt/hexstrike/tools/docker-bench-security && \
+    rm -rf /opt/hexstrike/tools/docker-bench-security/.git && \
+    printf '#!/bin/bash\nset -e\ncd /opt/hexstrike/tools/docker-bench-security\nexec ./docker-bench-security.sh "$@"\n' > /usr/local/bin/docker-bench-security && \
+    chmod +x /usr/local/bin/docker-bench-security
+
+# - clairctl: container vulnerability assessment CLI (amd64/arm64)
+# NOTE: currently clariictl does not work without a running clair server + postgresql in separate containers
+RUN arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) url="https://github.com/quay/clair/releases/latest/download/clairctl-linux-amd64";; \
+      arm64) url="https://github.com/quay/clair/releases/latest/download/clairctl-linux-arm64";; \
+      *) echo "unsupported arch for clairctl: $arch"; exit 1;; \
+    esac; \
+    curl -fsSL "$url" -o /usr/local/bin/clairctl; \
+    chmod 0755 /usr/local/bin/clairctl; \
+    /usr/local/bin/clairctl --version
+
+# - kube-bench: CIS Kubernetes benchmark auditing
+RUN tmp=$(mktemp -d); cd "$tmp"; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) suffix="amd64";; \
+      arm64) suffix="arm64";; \
+      *) echo "unsupported arch for kube-bench: $arch"; exit 1;; \
+    esac; \
+    tag=$(curl -fsSL https://api.github.com/repos/aquasecurity/kube-bench/releases/latest | jq -r '.tag_name'); \
+    file="kube-bench_${tag#v}_linux_${suffix}.tar.gz"; \
+    curl -fsSL -o kube-bench.tgz "https://github.com/aquasecurity/kube-bench/releases/download/${tag}/${file}"; \
+    tar -xzf kube-bench.tgz; \
+    install -m 0755 kube-bench /usr/local/bin/kube-bench; \
+    cd /; rm -rf "$tmp"
+
+# Kubernetes CLI
+RUN set -euo pipefail; \
+  arch="$(dpkg --print-architecture)"; case "$arch" in amd64) karch="amd64";; arm64) karch="arm64";; *) echo "unsupported arch for kubectl: $arch"; exit 1;; esac; \
+  KVER="$(curl -fsSL https://dl.k8s.io/release/stable.txt)"; \
+  curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KVER}/bin/linux/${karch}/kubectl"; \
+  chmod 0755 /usr/local/bin/kubectl; \
+  /usr/local/bin/kubectl version --client --output=yaml >/dev/null
+
+# Install Docker CLI from official Docker repository to talk to host's Docker/Podman API socket 
+# Note: necessary for kube-bench
+RUN set -euo pipefail; \
+  # Add Docker's official GPG key:
+  install -m 0755 -d /etc/apt/keyrings; \
+  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc; \
+  chmod a+r /etc/apt/keyrings/docker.asc; \
+  # Add the repository to Apt sources:
+  echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+    trixie stable" | \
+    tee /etc/apt/sources.list.d/docker.list > /dev/null; \
+  apt-get update; \
+  # Install latest Docker CLI
+  apt-get install -y --no-install-recommends docker-ce-cli;
+
+# ==============================================================================
+# Phase 16: MCP Entry Points & Minimal Wrappers
+# ==============================================================================
+RUN set -eu; \
+    # CloudMapper wrapper: ensure execution via its dedicated venv
+    printf '#!/bin/bash\n/opt/venvs/cloudmapper/bin/python /opt/hexstrike/tools/cloudmapper/cloudmapper.py "$@"\n' \
+      > /usr/local/bin/cloudmapper && chmod +x /usr/local/bin/cloudmapper && \
+    # Insomnia CLI wrapper: run with isolated Node 18 runtime
+    printf '#!/bin/bash\nPATH=/opt/insomnia-node18/bin:$PATH NODE_PATH=/opt/insomnia/lib/node_modules exec /opt/insomnia/bin/inso "$@"\n' \
+      > /usr/local/bin/insomnia && chmod +x /usr/local/bin/insomnia && \
+    # StegSolve wrapper: run jar with Java
+    printf '#!/bin/bash\nexec java -jar /opt/stegsolve/stegsolve.jar "$@"\n' \
+      > /usr/local/bin/stegsolve && chmod +x /usr/local/bin/stegsolve && \
+    # JWT analyzer convenience wrapper
+    printf '#!/bin/bash\nexec python3 /opt/hexstrike/tools/jwt_tool/jwt_tool.py "$@"\n' \
+      > /usr/local/bin/jwt-analyzer && chmod +x /usr/local/bin/jwt-analyzer && \
+    # API schema analyzer helper (minimal, prints endpoints + verbs)
+    printf '#!/usr/bin/env python3\nimport json,sys\nif len(sys.argv)<2:\n print("Usage: api-schema-analyzer <schema-file>"); sys.exit(1)\npath=sys.argv[1]\nwith open(path,"r",encoding="utf-8") as h:\n data=json.load(h)\npaths=data.get("paths",{})\nprint(f"Endpoints: {len(paths)}")\nfor route,methods in paths.items():\n verbs=\", \".join(m.upper() for m in methods.keys())\n print(f\"- {route}: {verbs}\")\n' \
+      > /usr/local/bin/api-schema-analyzer && chmod +x /usr/local/bin/api-schema-analyzer && \
+    # GraphQL helpers via npx
+    printf '#!/bin/bash\nexec npx --yes graphql-playground-html "$@"\n' \
+      > /usr/local/bin/graphql-playground && chmod +x /usr/local/bin/graphql-playground && \
+    printf '#!/bin/bash\nexec npx --yes graphql-voyager "$@"\n' \
+      > /usr/local/bin/graphql-voyager && chmod +x /usr/local/bin/graphql-voyager && \
+    \
+    printf '#!/usr/bin/env python3\nimport runpy,sys\nsys.argv=["patator"]+sys.argv[1:]\nrunpy.run_path("/usr/share/patator/patator.py", run_name="__main__")\n' \
+      > /usr/local/bin/patator && chmod +x /usr/local/bin/patator && \
+    printf '#!/usr/bin/env node\nconst r=require("child_process").execSync("npm root -g").toString().trim();require(r+"/social-analyzer/index.js");\n' \
+      > /usr/local/bin/social-analyzer && chmod +x /usr/local/bin/social-analyzer && \
+    \
+    # hashcat-utils binary does not exist. Provide a real entry point the server checks
+    printf '#!/bin/bash\n# This launcher exists because the Debian/Kali package "hashcat-utils" ships multiple executables (e.g., cap2hccapx),\n# but no single binary literally named "hashcat-utils". The server health check expects that name.\n# We delegate to a real tool from the suite so the check is truthful; if tools are missing, this fails naturally.\nexec cap2hccapx "$@"\n' \
+      > /usr/local/bin/hashcat-utils && chmod +x /usr/local/bin/hashcat-utils && \
+    \
+    # Volatility name variants expected by the server
+    printf '#!/bin/bash\nexec python3 -m volatility3 "$@"\n' \
+      > /usr/local/bin/vol.py && chmod +x /usr/local/bin/vol.py && \
+    printf '#!/bin/bash\nexec python3 -m volatility3 "$@"\n' \
+      > /usr/local/bin/volatility && chmod +x /usr/local/bin/volatility && \
+    ln -sf /opt/hexstrike/venv/bin/vol             /usr/local/bin/volatility3 && \
+    ln -sf /opt/hexstrike/venv/bin/vol             /usr/local/bin/vol && \
+    \
+    # Compatibility aliases required by hexstrike_server.py ---
+    ln -sf /usr/bin/searchsploit                   /usr/local/bin/exploit-db && \
+    ln -sf /usr/local/bin/newman                   /usr/local/bin/postman && \
+    ln -sf /usr/bin/http                           /usr/local/bin/httpie && \
+    ln -sf /usr/local/bin/graphql-inspector        /usr/local/bin/graphql-scanner && \
+    ln -sf /usr/bin/tsk_loaddb                     /usr/local/bin/sleuthkit && \
+    ln -sf /usr/bin/msfconsole                     /usr/local/bin/metasploit && \
+    ln -sf /usr/local/bin/pwned                    /usr/local/bin/have-i-been-pwned && \
+    ln -sf /usr/local/bin/clairctl                 /usr/local/bin/clair && \
+    ln -sf /usr/bin/bulk_extractor                 /usr/local/bin/bulk-extractor && \
+    ln -sf /usr/local/bin/one_gadget               /usr/local/bin/one-gadget && \
+    ln -sf /root/.local/bin/censys                 /usr/local/bin/censys-cli && \
+    ln -sf /root/.local/bin/shodan                 /usr/local/bin/shodan-cli && \
+    ln -sf /opt/hexstrike/tools/libc-database/find /usr/local/bin/libc-database && \
+    ln -sf /opt/hexstrike/venv/bin/ROPgadget       /usr/local/bin/ropgadget && \
+    ln -sf /opt/hexstrike/venv/bin/pwn             /usr/local/bin/pwntools && \
+    ln -sf /root/.local/bin/scout                  /usr/local/bin/scout-suite && \
+    ln -sf /usr/bin/evil-winrm                     /usr/local/bin/evil-winrm && \
+    ln -sf /usr/bin/maltego                        /usr/local/bin/maltego && \
+    ln -sf /usr/share/ghidra/support/analyzeHeadless /usr/local/bin/analyzeHeadless && \
+    \
+    # Wordlists position for dirsearch as expected by server and client
+    mkdir -p /usr/share/wordlists/dirsearch /usr/share/wordlists/dirbuster && \
+    ln -sf /usr/share/wordlists/dirb/common.txt /usr/share/wordlists/dirsearch/common.txt && \
+    # Wordlists position for Gobuster/Feroxbuster as expected by server
+    ln -sf /usr/share/seclists/Discovery/Web-Content/directory-list-2.3-medium.txt \
+          /usr/share/wordlists/dirbuster/directory-list-2.3-medium.txt
+
+# Provide fix ExportProgramScript.java avoiding Ghidra NullPointerException
+COPY docker/files/ghidra/ExportProgramScript.java /usr/share/ghidra/Ghidra/Features/Base/ghidra_scripts/ExportProgramScript.java
+
+# ==============================================================================
+# Phase 17: Image Cleanup
+# ==============================================================================
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Hide Message from Kali developers on login
+    touch ~/.hushlogin
+
+# ==============================================================================
+# Phase 18: MCP Server and Runtime Configuration
+# ==============================================================================
+# Copy requirements.txt first for Docker layer caching optimization
+COPY requirements.txt /opt/hexstrike/
+
+# Install core Python dependencies into virtual environment
+# Production WSGI server for better performance than Flask dev server
+RUN pip install --no-cache-dir gunicorn -r /opt/hexstrike/requirements.txt
+
+VOLUME ["/root/.cache/trivy", \
+        "/root/.wpscan/db",   \
+        "/root/.config/amass", \
+        "/root/nuclei-templates", \
+        "/root/.msf4", \
+        "/workspace"]
+
+# Copy server code at the end to leverage Docker layer caching
+COPY hexstrike_server.py /opt/hexstrike/
+
+# Expose MCP server port
+EXPOSE 8888
+
+# Copy optimized entrypoint that pre-warms local caches and starts the MCP server
+COPY --chmod=0755 docker/config/entrypoint.sh docker/config/update-tools-databases.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/docker/build-docker-image-release.sh
+++ b/docker/build-docker-image-release.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# ==============================================================================
+# File: build-docker-image-release.sh
+# Description: Script to build the Docker image for HexStrike AI and capture logs with optimizations.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR/.."
+
+IMAGE_TAG="hexstrike-ai:v6.0"
+LOG_FILE="${BUILD_LOG:-build.log}"
+
+echo "[+] Building image with docker | log: ${LOG_FILE}" >&2
+
+# Enable BuildKit if Docker supports it; harmless if ignored.
+export DOCKER_BUILDKIT=1
+
+# Use --no-cache to avoid using cached layers and ensure a consistent build
+# Use --pull to always attempt to pull a newer version of the base image if available
+sudo docker build \
+  --tag "${IMAGE_TAG}" \
+  --no-cache --force-rm --squash --pull \
+  --file docker/Dockerfile . \
+  2>&1 | tee "${LOG_FILE}"

--- a/docker/build-docker-image.sh
+++ b/docker/build-docker-image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# ==============================================================================
+# File: build-docker-image.sh
+# Description: Script to build the Docker image for HexStrike AI and capture logs for development purpose.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
+cd "$SCRIPT_DIR/.."
+
+IMAGE_TAG="hexstrike-ai:v6.0"
+LOG_FILE="${BUILD_LOG:-logs/build.log}"
+
+echo "[+] Building image with docker | log: ${LOG_FILE}" >&2
+
+# Enable BuildKit if Docker supports it; harmless if ignored.
+export DOCKER_BUILDKIT=1
+
+sudo docker build \
+  --tag "${IMAGE_TAG}" \
+  --file docker/Dockerfile . \
+  2>&1 | tee "${LOG_FILE}"

--- a/docker/config/clair-config.yaml
+++ b/docker/config/clair-config.yaml
@@ -1,0 +1,19 @@
+# Clair v4 minimal configuration — bound to localhost (no external exposure)
+http_listen_addr: "127.0.0.1:10080"    # API (used by clairctl/MCP)
+introspection_addr: "127.0.0.1:6060"  # /healthz, /metrics
+
+indexer:
+  connstring: "host=127.0.0.1 port=5432 user=clair password=clair dbname=clair sslmode=disable"
+  migrations: true
+
+matcher:
+  connstring: "host=127.0.0.1 port=5432 user=clair password=clair dbname=clair sslmode=disable"
+  indexer_addr: "http://127.0.0.1:10080"
+  migrations: true
+
+notifier:
+  connstring: "host=127.0.0.1 port=5432 user=clair password=clair dbname=clair sslmode=disable"
+  migrations: true
+
+updaters:
+  sets: ["alpine", "aws", "rhel", "debian", "ubuntu", "oracle", "photon", "suse"]

--- a/docker/config/db-init/01_init_clair.sql
+++ b/docker/config/db-init/01_init_clair.sql
@@ -1,0 +1,11 @@
+-- Create role if missing (idempotent)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'clair') THEN
+    CREATE ROLE clair WITH LOGIN PASSWORD 'clair';
+  END IF;
+END$$;
+
+-- Create database if missing (must be outside a transaction)
+SELECT 'CREATE DATABASE clair OWNER clair'
+WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'clair') \gexec

--- a/docker/config/db-init/02_init_metasploit.sql
+++ b/docker/config/db-init/02_init_metasploit.sql
@@ -1,0 +1,11 @@
+-- Create role if missing (idempotent)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'msf') THEN
+    CREATE ROLE msf WITH LOGIN PASSWORD 'msf';
+  END IF;
+END$$;
+
+-- Create database if missing (must be outside a transaction)
+SELECT 'CREATE DATABASE msf OWNER msf'
+WHERE NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = 'msf') \gexec

--- a/docker/config/entrypoint.sh
+++ b/docker/config/entrypoint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# HexStrike MCP minimal entrypoint
+# - Start server immediately
+# - Background update of security databases (best-effort)
+
+set -euo pipefail
+
+log()       { printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >&2; }
+log_error() { printf '[%s] ERROR: %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >&2; }
+
+# --- Metasploit DB bootstrap (one-time, idempotent) ---
+# Behavior:
+# - If MSF_DB_URL is empty or unset, skip DB bootstrap (not an error).
+# - If an active DB connection is already configured (db_status), skip bootstrap.
+# - Otherwise, connect once and persist settings via db_save (stored under /root/.msf4).
+if [ -z "${MSF_DB_URL:-}" ]; then
+  log "[msf] MSF_DB_URL is not set; skipping Metasploit DB bootstrap."
+else
+  if ! command -v msfconsole >/dev/null 2>&1; then
+    log_error "[msf] msfconsole not found in PATH; cannot bootstrap DB."
+  else
+    log "[msf] Checking current Metasploit DB status…"
+    if msfconsole -qx 'db_status; exit -y' | grep -q 'Connected to'; then
+      log "[msf] A data service is already configured; skipping bootstrap."
+    else
+      log "[msf] Initializing Metasploit DB config via db_connect…"
+      mkdir -p /root/.msf4
+      if msfconsole -qx "db_connect ${MSF_DB_URL}; db_save; db_status; exit -y"; then
+        log "[msf] Metasploit DB configured and persisted."
+      else
+        log_error "[msf] db_connect failed; leaving Metasploit unconfigured."
+      fi
+    fi
+  fi
+fi
+
+# --- Background updater (logs go to container stdout/stderr) ---
+if command -v /usr/local/bin/update-tools-databases.sh >/dev/null 2>&1; then
+  { /usr/local/bin/update-tools-databases.sh; } &
+else
+  log_error "[updater] /usr/local/bin/update-tools-databases.sh not found or not executable."
+fi
+
+# --- Start HexStrike MCP server ---
+GUNICORN_BIN="/opt/hexstrike/venv/bin/gunicorn"
+if [ ! -x "$GUNICORN_BIN" ]; then
+  log_error "[server] gunicorn not found or not executable at ${GUNICORN_BIN}."
+  exit 1
+fi
+
+log "[server] Starting HexStrike MCP server on 0.0.0.0:8888"
+exec "$GUNICORN_BIN" \
+  --bind 0.0.0.0:8888 \
+  --workers 2 \
+  --threads 8 \
+  --timeout 3600 \
+  --graceful-timeout 120 \
+  --keep-alive 60 \
+  "hexstrike_server:app"

--- a/docker/config/update-tools-databases.sh
+++ b/docker/config/update-tools-databases.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Update vulnerability/security tool databases for the HexStrike AI container.
+# Scope: environment-only refresh steps (no scanning).
+
+
+set -euo pipefail
+
+log()       { printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >&2; }
+log_error() { printf '[%s] ERROR: %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" >&2; }
+
+HOME="${HOME:-/root}"
+
+log "=== HexStrike updater: starting ==="
+
+# --- Sanity overview (missing => ERROR) ---
+if [ -d "$HOME/.wpscan/db" ]; then
+  log "WPScan DB dir:        ${HOME}/.wpscan/db  [present]"
+else
+  log_error "WPScan DB dir missing: ${HOME}/.wpscan/db"
+fi
+
+if [ -d "$HOME/.cache/trivy" ]; then
+  log "Trivy cache dir:      ${HOME}/.cache/trivy  [present]"
+else
+  log_error "Trivy cache dir missing: ${HOME}/.cache/trivy"
+fi
+
+if [ -d "$HOME/nuclei-templates" ]; then
+  log "Nuclei templates dir: ${HOME}/nuclei-templates  [present]"
+else
+  log_error "Nuclei templates dir missing: ${HOME}/nuclei-templates"
+fi
+
+if [ -d "/usr/share/exploitdb" ]; then
+  log "ExploitDB dir:        /usr/share/exploitdb  [present]"
+else
+  log_error "ExploitDB dir missing: /usr/share/exploitdb"
+fi
+
+if [ -d "/var/lib/nikto" ]; then
+  log "Nikto data dir:       /var/lib/nikto  [present]"
+else
+  log_error "Nikto data dir missing: /var/lib/nikto"
+fi
+
+if [ -f "/usr/share/nmap/scripts/script.db" ]; then
+  log "Nmap scripts DB:      /usr/share/nmap/scripts/script.db  [present]"
+else
+  log_error "Nmap scripts DB missing: /usr/share/nmap/scripts/script.db"
+fi
+
+if [ -d "$HOME/.ZAP" ]; then
+  log "ZAP home:             ${HOME}/.ZAP  [present]"
+else
+  log_error "ZAP home missing: ${HOME}/.ZAP (it will be created on first run)"
+fi
+
+# --- WPScan DB update ---
+log "WPScan: updating vulnerability DB…"
+if command -v wpscan >/dev/null 2>&1; then
+  if ! wpscan --update; then
+    log_error "WPScan DB update failed (non-zero exit)"
+  fi
+else
+  log_error "WPScan binary not found in PATH"
+fi
+
+# --- Trivy DB download (no scan) ---
+if command -v trivy >/dev/null 2>&1; then
+  if ! trivy image --download-db-only --cache-dir "${HOME}/.cache/trivy"; then
+    log_error "Trivy DB download failed (non-zero exit)"
+  fi
+else
+  log_error "Trivy binary not found in PATH"
+fi
+
+# --- Nmap scripts DB refresh ---
+log "Nmap: refreshing scripts database…"
+if command -v nmap >/dev/null 2>&1; then
+  if ! nmap --script-updatedb; then
+    log_error "Nmap script-updatedb failed (non-zero exit)"
+  fi
+else
+  log_error "Nmap binary not found in PATH"
+fi
+
+# --- OWASP ZAP add-ons (headless) ---
+# Bind to a dedicated, non-conflicting port to avoid "Address already in use".
+log "ZAP: updating add-ons (headless)…"
+if command -v zaproxy >/dev/null 2>&1; then
+  if ! zaproxy -cmd -silent -port 8099 -addonupdate; then
+    log_error "ZAP add-on update failed (non-zero exit)"
+  fi
+else
+  log_error "ZAP (zaproxy) binary not found in PATH"
+fi
+
+# --- Nuclei templates update ---
+log "Nuclei: updating templates…"
+if command -v nuclei >/dev/null 2>&1; then
+  if ! nuclei -update-templates; then
+    log_error "Nuclei templates update failed (non-zero exit)"
+  fi
+else
+  log_error "Nuclei binary not found in PATH"
+fi
+
+log "=== HexStrike updater: done ==="

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,169 @@
+# ==============================================================================
+# HexStrike AI MCP Server v6.0 - Docker Compose Configuration
+# ==============================================================================
+# This compose file provides easy deployment of HexStrike MCP server
+# with proper network capabilities and volume mounts
+# ==============================================================================
+
+version: "3.8"
+
+services:
+  # ----------------------------------------------------------------------------
+  # HexStrike MCP Server
+  # ----------------------------------------------------------------------------
+  hexstrike-mcp-server:
+    # Build configuration
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+
+    # Container name for easy reference
+    container_name: hexstrike-mcp-server
+
+    # Image name and tag
+    image: hexstrike-ai:v6.0
+
+    # Environment variables
+    environment:
+      - PYTHONUNBUFFERED=1
+      - COMMAND_TIMEOUT=3600
+      # - DEBUG_MODE=true
+      # - MCP_PORT=8888
+      # Clair API
+      - CLAIR_ADDR=http://127.0.0.1:10080
+      # Metasploit DB URL (empty = disabled)
+      - MSF_DB_URL=postgresql://msf:msf@127.0.0.1:5432/msf
+
+    volumes:
+      - ../logs/hexstrike.log:/opt/hexstrike/hexstrike.log:rw,Z
+      - ./config/clair-config.yaml:/etc/clair/config.yaml:ro,Z
+      - ../data/trivy:/root/.cache/trivy:rw,Z
+      - ../data/wpscan:/root/.wpscan/db:rw,Z
+      - ../data/nuclei-templates:/root/nuclei-templates:rw,Z
+      - ../data/amass:/root/.config/amass:rw,Z
+      - ../data/msf:/root/.msf4:rw,Z
+      - ../data/exploitdb:/usr/share/exploitdb:rw,Z
+      - ../data/zap:/root/.ZAP:rw,Z
+      # Mount workspace used by checkov_iac_scan as default location
+      - ../data/workspace:/workspace:rw,Z
+      # Necessay mounts for kube-bench that neeed host socket access
+      - /var/run/docker.sock:/var/run/docker.sock        # Docker API socket (shim in case of Podman)
+      # Add this volume below if you have podman
+      - /run/podman/podman.sock:/run/podman/podman.sock  # Podman API socket
+      # Optional: mount kube-bench config. MCP client also can pass --config_dir for custom path
+      # - ../data/kube-bench:/etc/kube-bench
+
+    # Restart policy suitable for production
+    restart: unless-stopped
+
+    # Health check configuration
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8888/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+    # Give the container full host networking (required by many scanners/sniffers)
+    network_mode: "host"
+
+    # ==============================================================================
+    # PRIVILEGED MODE - Maximum Tool Compatibility (127 security tools)
+    # ==============================================================================
+    # Enabled to guarantee all pentesting tools work without capability issues.
+    # This includes: nmap, masscan, metasploit, wireshark, tcpdump, aircrack-ng,
+    # docker-bench, kube-hunter, falco, volatility, gdb, radare2, etc.
+    #
+    # Security Note: Safe in controlled pentesting environments with network_mode: host.
+    # For hardening, disable privileged and use cap_add below (require testing).
+    # ==============================================================================
+    privileged: true
+
+    # ==============================================================================
+    # ALTERNATIVE: Fine-grained Capabilities (if privileged: false)
+    # ==============================================================================
+    # Uncomment these if you disable privileged mode and want granular control.
+    # Note: Some tools may still fail without privileged mode.
+    # ==============================================================================
+    # cap_add:
+    #   - NET_RAW           # Raw sockets (nmap -sS, masscan, tcpdump, wireshark)
+    #   - NET_ADMIN         # Network management (ip, ifconfig, airmon-ng, responder)
+    #   - NET_BIND_SERVICE  # Bind ports < 1024 (metasploit, zaproxy, burpsuite)
+    #   - NET_BROADCAST     # Broadcast packets (ARP scan, responder)
+    #   - SYS_ADMIN         # Mount, namespace, advanced operations (docker-bench, containers)
+    #   - SYS_PTRACE        # Debugging/tracing (gdb, strace, volatility)
+    #   - SYS_CHROOT        # Chroot operations (some exploitation tools)
+    #   - DAC_OVERRIDE      # Bypass file permission checks (forensics tools)
+    #   - DAC_READ_SEARCH   # Bypass directory read permission checks
+    #   - SETUID            # Set UID (some exploitation scenarios)
+    #   - SETGID            # Set GID (some exploitation scenarios)
+    #   - SETPCAP           # Set process capabilities
+    #   - SYS_MODULE        # Load kernel modules (advanced wireless tools)
+    #   - SYS_RAWIO         # Raw I/O (direct hardware access)
+    #   - IPC_LOCK          # Lock memory (prevent swapping sensitive data)
+    #   - SYS_NICE          # Change process priority
+
+    # Security knobs for RHEL/Alma SELinux compatibility
+    security_opt:
+      - seccomp=unconfined  # Allow all syscalls (required for raw sockets and advanced tools)
+      - apparmor=unconfined # Disable AppArmor on Debian/Ubuntu hosts
+      - label=disable       # Disable SELinux labeling inside container for CentOS/RHEL hosts
+
+    # File descriptors & shared memory (Chromium/ZAP/Burp can need bigger /dev/shm)
+    ulimits:
+      nofile: 65536
+    shm_size: "1g"
+
+    # Optional devices (enable if needed for USB wireless cards or VPN testing)
+    # devices:
+    #   - "/dev/bus/usb:/dev/bus/usb"        # USB wireless adapters (airmon-ng, kismet)
+    #   - "/dev/net/tun:/dev/net/tun"        # TUN/TAP for VPN testing
+
+  # ------------------------------------------------------------------------------
+  # Clair v4 - Container image and vulnerability scanning API
+  # - Default: connect to local Postgres service "hexstrike-postgres"
+  # - External DB: change the connstring in ./config/clair-config.yaml to point to your external PostgreSQL
+  # ------------------------------------------------------------------------------
+  hexstrike-clair:
+    image: quay.io/projectquay/clair:4.8.0
+    pull_policy: always
+    container_name: hexstrike-clair
+    restart: unless-stopped
+    network_mode: "host"
+    volumes:
+      - ./config/clair-config.yaml:/etc/clair/config.yaml:ro,Z
+    command: ["-conf=/etc/clair/config.yaml"]
+    depends_on:
+      hexstrike-postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:6060/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  # ----------------------------------------------------------------------------
+  # PostgreSQL 18 — local DB for Clair (and optional Metasploit)
+  # ----------------------------------------------------------------------------
+  hexstrike-postgres:
+    image: docker.io/postgres:18
+    pull_policy: always
+    container_name: hexstrike-postgres
+    restart: unless-stopped
+    user: "999:999"
+    environment:
+      POSTGRES_PASSWORD: postgres
+    # Bind Postgres only to localhost on host network
+    network_mode: "host"
+    command: ["-c", "listen_addresses=127.0.0.1"]
+    volumes:
+      # DB init scripts live here (create users/databases, etc.)
+      - ./config/db-init:/docker-entrypoint-initdb.d:ro,Z
+      # Mount the parent; the image manages the child path internally
+      - ../data/postgres:/var/lib/postgresql:Z,U
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -h 127.0.0.1 -p 5432 -d clair"]
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/docker/files/ghidra/ExportProgramScript.java
+++ b/docker/files/ghidra/ExportProgramScript.java
@@ -1,0 +1,176 @@
+/* ###
+ * IP: GHIDRA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//Example script to show how to export the current program in its original binary format by 
+//looking at the original bytes compared to the current bytes and exporting the original if they 
+//are the same and the current bytes if they are different. If the changed bytes are relocations, 
+//the original bytes are used. The script only handles simple use cases.
+//@category Examples
+
+import java.io.*;
+import java.util.Iterator;
+import java.util.List;
+
+import ghidra.app.script.GhidraScript;
+import ghidra.program.database.mem.FileBytes;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.address.AddressSet;
+import ghidra.program.model.mem.Memory;
+import ghidra.program.model.reloc.Relocation;
+import ghidra.program.model.reloc.RelocationTable;
+import ghidra.util.exception.CancelledException;
+
+public class ExportProgramScript extends GhidraScript {
+
+	@Override
+	public void run() throws Exception {
+
+		if (currentProgram == null) {
+			println("Must have an open program");
+			return;
+		}
+
+		File outBinaryFile = askFile("Select Binary Output File", "Binary File");
+
+		if (outBinaryFile.exists()) {
+			if (!askYesNo("Binary File Already Exists",
+				"The binary file already exists.\nDo you want to overwrite it?")) {
+				return;
+			}
+		}
+
+		// make address set of relocation byte addresses
+		AddressSet relocationAddrs = new AddressSet();
+
+		RelocationTable relocTable = currentProgram.getRelocationTable();
+		Iterator<Relocation> iter = relocTable.getRelocations();
+		while (iter.hasNext()) {
+			monitor.checkCancelled();
+
+			Relocation reloc = iter.next();
+
+			// FIX: if relocation is null continue without NullPointerException
+			byte[] relocBytes = reloc.getBytes();
+			if (relocBytes == null) {
+				continue;
+			}
+
+			Address relocStart = reloc.getAddress();
+			int rlocLen = reloc.getBytes().length;
+			relocationAddrs.add(relocStart, relocStart.add(rlocLen));
+			
+
+		}
+
+		// create an output stream
+		OutputStream out = new FileOutputStream(outBinaryFile);
+
+		// get all program file bytes
+		Memory memory = currentProgram.getMemory();
+		List<FileBytes> allFileBytes = memory.getAllFileBytes();
+		if (allFileBytes.isEmpty()) {
+			println(
+				"Cannot access original file bytes. Either the program was imported before Ghidra " +
+					"started saving original file bytes or the program was not imported directly from the " +
+					"original binary.");
+			out.close();
+			return;
+		}
+
+		//TODO: update to handle multiple case once FileBytes adds new method to support it
+		if (allFileBytes.size() > 1) {
+			println(
+				"*** This program was created using multiple imported programs. This script will currently only work if the program was created with a single imported file.");
+			out.close();
+			return;
+		}
+
+		//Get the original import file bytes
+		FileBytes fileBytes = allFileBytes.get(0);
+
+		long size = fileBytes.getSize();
+		println(
+			"Exporting current program to a new binary file including any changes to the original " +
+				"except for relocation changes...");
+
+		// compare each original imported byte with the current program byte at the equivalent location
+		// if the current byte is different and is not a relocation, export that byte instead of
+		// the original
+		for (long i = 0; i < size; i++) {
+
+			monitor.checkCancelled();
+
+			byte originalByte = fileBytes.getOriginalByte(i);
+			byte currentByte = fileBytes.getModifiedByte(i);
+
+			int original = originalByte & 0xff;
+			int current = currentByte & 0xff;
+
+			if (originalByte != currentByte) {
+
+				// TODO: once new method is created to use the fileBytes and offset to retrieve the
+				// address, update this to use the correct method and lift the above restriction 
+				// on only handling one imported file.
+				List<Address> addresses = memory.locateAddressesForFileOffset(i);
+
+
+				// NOTE: It is rare that there would be more than one address in the program corresponding
+				// to a given offset but check anyway and if any of them are a relocation then 
+				// output the original byte
+				if (!addressSetContainsAnyInList(relocationAddrs, addresses)) {
+
+					println(addresses +
+						": Writing out changed byte since it is not a relocation. File offset = " +
+						i + ", originalByte = " + Integer.toHexString(original) +
+						", changed to = " + Integer.toHexString(current));
+					println("****** ");
+					out.write(current);
+
+				}
+				else {
+					// Not writing out change since it is a relocation
+					out.write(original);
+				}
+
+			}
+			// same in current and original
+			else {
+				out.write(original);
+			}
+		}
+
+		out.close();
+		println("Done!");
+	}
+
+	private boolean addressSetContainsAnyInList(AddressSet set, List<Address> list)
+			throws CancelledException {
+
+		if (list.isEmpty()) {
+			return false;
+		}
+		if (set.isEmpty()) {
+			return false;
+		}
+
+		for (Address address : list) {
+			monitor.checkCancelled();
+			if (set.contains(address)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/docker/start-docker-mcp-server.sh
+++ b/docker/start-docker-mcp-server.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &>/dev/null && pwd )"
+
+cd $SCRIPT_DIR
+
+# create host-side folders used by docker-compose bind mounts
+mkdir -p \
+  "../logs" \
+  "../data/trivy" \
+  "../data/wpscan" \
+  "../data/nuclei-templates" \
+  "../data/amass" \
+  "../data/msf" \
+  "../data/postgres" \
+  "../data/workspace" \
+
+[ -f "../logs/hexstrike.log" ] || touch "../logs/hexstrike.log"
+
+sudo docker-compose \
+  -f "./docker-compose.yml" \
+  up -d --force-recreate

--- a/hexstrike_mcp.py
+++ b/hexstrike_mcp.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# hexstrike_mcp.py
 """
 HexStrike AI MCP Client - Enhanced AI Agent Communication Interface
 
@@ -160,34 +161,36 @@ class HexStrikeClient:
         self.session = requests.Session()
 
         # Try to connect to server with retries
-        connected = False
-        for i in range(MAX_RETRIES):
-            try:
-                logger.info(f"🔗 Attempting to connect to HexStrike AI API at {server_url} (attempt {i+1}/{MAX_RETRIES})")
-                # First try a direct connection test before using the health endpoint
+        # If running under an MCP host (stdio not attached to a TTY), skip HTTP health checks to avoid bootstrap delays.
+        if sys.stdin.isatty() or sys.stdout.isatty():
+            connected = False
+            for i in range(MAX_RETRIES):
                 try:
-                    test_response = self.session.get(f"{self.server_url}/health", timeout=5)
-                    test_response.raise_for_status()
-                    health_check = test_response.json()
-                    connected = True
-                    logger.info(f"🎯 Successfully connected to HexStrike AI API Server at {server_url}")
-                    logger.info(f"🏥 Server health status: {health_check.get('status', 'unknown')}")
-                    logger.info(f"📊 Server version: {health_check.get('version', 'unknown')}")
-                    break
-                except requests.exceptions.ConnectionError:
-                    logger.warning(f"🔌 Connection refused to {server_url}. Make sure the HexStrike AI server is running.")
-                    time.sleep(2)  # Wait before retrying
+                    logger.info(f"🔗 Attempting to connect to HexStrike AI API at {server_url} (attempt {i+1}/{MAX_RETRIES})")
+                    try:
+                        test_response = self.session.get(f"{self.server_url}/health", timeout=5)
+                        test_response.raise_for_status()
+                        health_check = test_response.json()
+                        connected = True
+                        logger.info(f"🎯 Successfully connected to HexStrike AI API Server at {server_url}")
+                        logger.info(f"🏥 Server health status: {health_check.get('status', 'unknown')}")
+                        logger.info(f"📊 Server version: {health_check.get('version', 'unknown')}")
+                        break
+                    except requests.exceptions.ConnectionError:
+                        logger.warning(f"🔌 Connection refused to {server_url}. Make sure the HexStrike AI server is running.")
+                        time.sleep(2)
+                    except Exception as e:
+                        logger.warning(f"⚠️  Connection test failed: {str(e)}")
+                        time.sleep(2)
                 except Exception as e:
-                    logger.warning(f"⚠️  Connection test failed: {str(e)}")
-                    time.sleep(2)  # Wait before retrying
-            except Exception as e:
-                logger.warning(f"❌ Connection attempt {i+1} failed: {str(e)}")
-                time.sleep(2)  # Wait before retrying
-
-        if not connected:
-            error_msg = f"Failed to establish connection to HexStrike AI API Server at {server_url} after {MAX_RETRIES} attempts"
-            logger.error(error_msg)
-            # We'll continue anyway to allow the MCP server to start, but tools will likely fail
+                    logger.warning(f"❌ Connection attempt {i+1} failed: {str(e)}")
+                    time.sleep(2)
+            if not connected:
+                error_msg = f"Failed to establish connection to HexStrike AI API Server at {server_url} after {MAX_RETRIES} attempts"
+                logger.error(error_msg)
+                # continue anyway; MCP stdio server will still start
+        else:
+            logger.info("🧪 Stdio host detected (non-TTY). Skipping HTTP health checks and starting MCP stdio immediately.")
 
     def safe_get(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """
@@ -419,7 +422,7 @@ def setup_mcp_server(hexstrike_client: HexStrikeClient) -> FastMCP:
     # ============================================================================
 
     @mcp.tool()
-    def prowler_scan(provider: str = "aws", profile: str = "default", region: str = "", checks: str = "", output_dir: str = "/tmp/prowler_output", output_format: str = "json", additional_args: str = "") -> Dict[str, Any]:
+    def prowler_scan(provider: str = "aws", profile: str = "default", region: str = "", checks: str = "", output_dir: str = "/tmp/prowler_output", output_format: str = "json-ocsf", additional_args: str = "") -> Dict[str, Any]:
         """
         Execute Prowler for comprehensive cloud security assessment.
 
@@ -2672,46 +2675,6 @@ def setup_mcp_server(hexstrike_client: HexStrikeClient) -> FastMCP:
             logger.error(f"❌ Dalfox XSS scan failed")
         return result
 
-    @mcp.tool()
-    def httpx_probe(target: str, probe: bool = True, tech_detect: bool = False,
-                   status_code: bool = False, content_length: bool = False,
-                   title: bool = False, web_server: bool = False, threads: int = 50,
-                   additional_args: str = "") -> Dict[str, Any]:
-        """
-        Execute httpx for fast HTTP probing and technology detection.
-
-        Args:
-            target: Target file or single URL
-            probe: Enable probing
-            tech_detect: Enable technology detection
-            status_code: Show status codes
-            content_length: Show content length
-            title: Show page titles
-            web_server: Show web server
-            threads: Number of threads
-            additional_args: Additional httpx arguments
-
-        Returns:
-            Fast HTTP probing results with technology detection
-        """
-        data = {
-            "target": target,
-            "probe": probe,
-            "tech_detect": tech_detect,
-            "status_code": status_code,
-            "content_length": content_length,
-            "title": title,
-            "web_server": web_server,
-            "threads": threads,
-            "additional_args": additional_args
-        }
-        logger.info(f"🌍 Starting httpx probe: {target}")
-        result = hexstrike_client.safe_post("api/tools/httpx", data)
-        if result.get("success"):
-            logger.info(f"✅ httpx probe completed for {target}")
-        else:
-            logger.error(f"❌ httpx probe failed for {target}")
-        return result
 
     @mcp.tool()
     def anew_data_processing(input_data: str, output_file: str = "",
@@ -2907,7 +2870,7 @@ def setup_mcp_server(hexstrike_client: HexStrikeClient) -> FastMCP:
             logger.info(f"🤖 Generating {attack_type} payloads...")
 
             # Generate payloads for this attack type
-            payload_result = self.ai_generate_payload(attack_type, "advanced", "", target_url)
+            payload_result = ai_generate_payload(attack_type, "advanced", "", target_url)
 
             if payload_result.get("success"):
                 payload_data = payload_result.get("ai_payload_generation", {})
@@ -5459,7 +5422,16 @@ def main():
         mcp = setup_mcp_server(hexstrike_client)
         logger.info("🚀 Starting HexStrike AI MCP server")
         logger.info("🤖 Ready to serve AI agents with enhanced cybersecurity capabilities")
-        mcp.run()
+        # Minimal stdio fallback for MCP clients that require stdio transport.
+        try:
+            mcp.run()
+        except AttributeError:
+            # Older/newer FastMCP variants expose an async stdio runner.
+            import asyncio
+            if hasattr(mcp, "run_stdio"):
+                asyncio.run(mcp.run_stdio())
+            else:
+                raise
     except Exception as e:
         logger.error(f"💥 Error starting MCP server: {str(e)}")
         import traceback

--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# hexstrike_server.py
 """
 HexStrike AI - Advanced Penetration Testing Framework Server
 
@@ -31,6 +32,7 @@ import hashlib
 import pickle
 import base64
 import queue
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Dict, Any, Optional
@@ -844,12 +846,12 @@ class IntelligentDecisionEngine:
                 return TargetType.API_ENDPOINT
             return TargetType.WEB_APPLICATION
 
-        # IP address pattern
-        if re.match(r'^(\d{1,3}\.){3}\d{1,3}$', target):
+        # IP address pattern (port optional)
+        if re.match(r'^(\d{1,3}\.){3}\d{1,3}(:\d{1,5})?$', target):
             return TargetType.NETWORK_HOST
 
-        # Domain name pattern
-        if re.match(r'^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$', target):
+        # Domain name pattern (port optional)
+        if re.match(r'^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(:\d{1,5})?$', target):
             return TargetType.WEB_APPLICATION
 
         # File patterns
@@ -8633,13 +8635,14 @@ cve_intelligence = CVEIntelligenceManager()
 exploit_generator = AIExploitGenerator()
 vulnerability_correlator = VulnerabilityCorrelator()
 
-def execute_command(command: str, use_cache: bool = True) -> Dict[str, Any]:
+def execute_command(command: str, use_cache: bool = True, timeout: int = COMMAND_TIMEOUT) -> Dict[str, Any]:
     """
     Execute a shell command with enhanced features
 
     Args:
         command: The command to execute
         use_cache: Whether to use caching for this command
+        timeout: Maximum execution time in seconds for the command
 
     Returns:
         A dictionary containing the stdout, stderr, return code, and metadata
@@ -8651,8 +8654,8 @@ def execute_command(command: str, use_cache: bool = True) -> Dict[str, Any]:
         if cached_result:
             return cached_result
 
-    # Execute command
-    executor = EnhancedCommandExecutor(command)
+    # Execute command (propagate timeout to the executor)
+    executor = EnhancedCommandExecutor(command, timeout=timeout)
     result = executor.execute()
 
     # Cache successful results
@@ -9093,14 +9096,18 @@ def health_check():
         password_tools + binary_tools + forensics_tools + cloud_tools +
         osint_tools + exploitation_tools + api_tools + wireless_tools + additional_tools
     )
+    # De-duplicate combined tool list to avoid inflated totals when a tool appears in multiple categories
+    unique_tools = sorted(set(all_tools))
     tools_status = {}
 
-    for tool in all_tools:
+    # Iterate once over unique tool names
+    for tool in unique_tools:
         try:
             result = execute_command(f"which {tool}", use_cache=True)
             tools_status[tool] = result["success"]
-        except:
+        except Exception:
             tools_status[tool] = False
+
 
     all_essential_tools_available = all(tools_status[tool] for tool in essential_tools)
 
@@ -9126,8 +9133,8 @@ def health_check():
         "version": "6.0.0",
         "tools_status": tools_status,
         "all_essential_tools_available": all_essential_tools_available,
-        "total_tools_available": sum(1 for tool, available in tools_status.items() if available),
-        "total_tools_count": len(all_tools),
+        "total_tools_available": sum(1 for _, available in tools_status.items() if available),
+        "total_tools_count": len(unique_tools),
         "category_stats": category_stats,
         "cache_stats": cache.get_stats(),
         "telemetry": telemetry.get_stats(),
@@ -9773,7 +9780,8 @@ def intelligent_smart_scan():
                 }
 
         # Execute tools in parallel using ThreadPoolExecutor
-        with ThreadPoolExecutor(max_workers=min(len(selected_tools), 5)) as executor:
+        workers = max(1, min(len(selected_tools), 5))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
             # Submit all tool executions
             future_to_tool = {
                 executor.submit(execute_single_tool, tool, target, profile): tool
@@ -9822,24 +9830,107 @@ def intelligent_smart_scan():
         return jsonify({"error": f"Server error: {str(e)}", "success": False}), 500
 
 # Helper functions for intelligent smart scan tool execution
-def execute_nmap_scan(target, params):
-    """Execute nmap scan with optimized parameters"""
+def execute_nmap_scan(target: str, params: dict):
+    """
+    Execute nmap with safe target cleanup.
+    - If `target` is a URL, pass to nmap only host[:port]
+      (e.g. http://127.0.0.1:3000 -> host=127.0.0.1, port=3000).
+    - If a port is present, prepend it to user-provided `ports`.
+    - No imports added; relies on existing `re` and `execute_command`.
+    """
     try:
-        scan_type = params.get('scan_type', '-sV')
-        ports = params.get('ports', '')
-        additional_args = params.get('additional_args', '')
+        params = params or {}
+        scan_type = (params.get("scan_type") or "-sV").strip()
+        ports = (params.get("ports") or "").strip()
+        additional_args = (params.get("additional_args") or "").strip()
 
-        # Build nmap command
-        cmd_parts = ['nmap', scan_type]
-        if ports:
-            cmd_parts.extend(['-p', ports])
+        raw = (target or "").strip()
+
+        # Strip scheme if present (http://, https://, etc.)
+        m = re.match(r'^[a-zA-Z][a-zA-Z0-9+.\-]*://(.+)$', raw)
+        netloc = m.group(1) if m else raw
+
+        # Cut off path/query/fragment
+        for sep in ("/", "?", "#"):
+            i = netloc.find(sep)
+            if i != -1:
+                netloc = netloc[:i]
+                break
+
+        # Extract host and (optional) port
+        host = netloc
+        url_port = None
+
+        if host.startswith("["):  # [IPv6]:port
+            j = host.find("]")
+            if j != -1:
+                inside = host[1:j]
+                rest = host[j+1:]
+                host = inside
+                if rest.startswith(":"):
+                    p = rest[1:]
+                    if p.isdigit():
+                        url_port = int(p)
+        else:
+            # Heuristic: treat single-colon forms as host:port (IPv4/hostname)
+            if host.count(":") == 1:
+                h, p = host.split(":", 1)
+                if p.isdigit():
+                    host = h
+                    url_port = int(p)
+
+        # Merge URL port into -p if present
+        merged_ports = ports
+        if url_port:
+            merged_ports = f"{url_port}" + (f",{merged_ports}" if merged_ports else "")
+
+        # Build command line
+        cmd_parts = ["nmap"]
+        if scan_type:
+            cmd_parts.extend(scan_type.split())
+        if merged_ports:
+            cmd_parts.extend(["-p", merged_ports])
         if additional_args:
             cmd_parts.extend(additional_args.split())
-        cmd_parts.append(target)
+        cmd_parts.append(host)
 
-        return execute_command(' '.join(cmd_parts))
+        return execute_command(" ".join(cmd_parts))
     except Exception as e:
         return {"success": False, "error": str(e)}
+
+def _auto_handle_gobuster_wildcard(url: str, mode: str, additional_args: str) -> Tuple[str, Optional[str]]:
+    """Ensure gobuster handles wildcard responses from targets like Juice Shop."""
+    additional_args = (additional_args or "").strip()
+
+    # Only dir mode needs 200-everywhere mitigation
+    if mode != "dir" or not url:
+        return additional_args, None
+
+    # Respect explicit user handling
+    wildcard_keywords = ["--wildcard", "--exclude-length", "--exclude-status", "-b", "--status-codes"]
+    if any(keyword in additional_args for keyword in wildcard_keywords):
+        return additional_args, None
+
+    candidate_flag: Optional[str] = None
+
+    try:
+        random_path = uuid.uuid4().hex[:12]
+        normalized = url if url.endswith('/') else f"{url}/"
+        probe_url = urllib.parse.urljoin(normalized, random_path)
+        response = requests.get(probe_url, timeout=5, verify=False)
+
+        # If the target reflects wildcard successes, reuse that body length
+        if response.status_code < 500 and response.content:
+            candidate_flag = f"--exclude-length {len(response.content)}"
+    except Exception as exc:
+        logger.debug(f"Gobuster wildcard probe failed ({exc}); falling back to --wildcard")
+
+    if not candidate_flag:
+        candidate_flag = "--wildcard"
+
+    adjusted_args = f"{additional_args} {candidate_flag}".strip()
+    return adjusted_args, candidate_flag
+
 
 def execute_gobuster_scan(target, params):
     """Execute gobuster scan with optimized parameters"""
@@ -9848,9 +9939,14 @@ def execute_gobuster_scan(target, params):
         wordlist = params.get('wordlist', '/usr/share/wordlists/dirb/common.txt')
         additional_args = params.get('additional_args', '')
 
+        adjusted_args, auto_flag = _auto_handle_gobuster_wildcard(target, mode, additional_args)
+
         cmd_parts = ['gobuster', mode, '-u', target, '-w', wordlist]
-        if additional_args:
-            cmd_parts.extend(additional_args.split())
+        if adjusted_args:
+            cmd_parts.extend(adjusted_args.split())
+
+        if auto_flag:
+            logger.info(f"🧪 Auto-adjusted Gobuster args with {auto_flag}")
 
         return execute_command(' '.join(cmd_parts))
     except Exception as e:
@@ -10329,7 +10425,7 @@ def nmap():
     """Execute nmap scan with enhanced logging, caching, and intelligent error handling"""
     try:
         params = request.json
-        target = params.get("target", "")
+        target = (params.get("target") or "").strip()
         scan_type = params.get("scan_type", "-sCV")
         ports = params.get("ports", "")
         additional_args = params.get("additional_args", "-T4 -Pn")
@@ -10385,6 +10481,8 @@ def gobuster():
         additional_args = params.get("additional_args", "")
         use_recovery = params.get("use_recovery", True)
 
+        adjusted_args, auto_flag = _auto_handle_gobuster_wildcard(url, mode, additional_args)
+
         if not url:
             logger.warning("🌐 Gobuster called without URL parameter")
             return jsonify({
@@ -10400,8 +10498,11 @@ def gobuster():
 
         command = f"gobuster {mode} -u {url} -w {wordlist}"
 
-        if additional_args:
-            command += f" {additional_args}"
+        if adjusted_args:
+            command += f" {adjusted_args}"
+
+        if auto_flag:
+            logger.info(f"🧪 Applied Gobuster auto-adjustment: {auto_flag}")
 
         logger.info(f"📁 Starting Gobuster {mode} scan: {url}")
 
@@ -10411,7 +10512,8 @@ def gobuster():
                 "target": url,
                 "mode": mode,
                 "wordlist": wordlist,
-                "additional_args": additional_args
+                "additional_args": adjusted_args,
+                "auto_adjustment": auto_flag
             }
             result = execute_command_with_recovery("gobuster", command, tool_params)
         else:
@@ -10496,7 +10598,7 @@ def prowler():
         region = params.get("region", "")
         checks = params.get("checks", "")
         output_dir = params.get("output_dir", "/tmp/prowler_output")
-        output_format = params.get("output_format", "json")
+        output_format = params.get("output_format", "json-ocsf")
         additional_args = params.get("additional_args", "")
 
         # Ensure output directory exists
@@ -10514,7 +10616,7 @@ def prowler():
             command += f" --checks {checks}"
 
         command += f" --output-directory {output_dir}"
-        command += f" --output-format {output_format}"
+        command += f" --output-formats {output_format}"
 
         if additional_args:
             command += f" {additional_args}"
@@ -10831,10 +10933,12 @@ def clair():
             return jsonify({"error": "Image parameter is required"}), 400
 
         # Use clairctl for scanning
-        command = f"clairctl analyze {image}"
+        command = "clairctl"
 
         if config:
             command += f" --config {config}"
+
+        command += f" report {image}"
 
         if output_format:
             command += f" --format {output_format}"
@@ -10864,10 +10968,10 @@ def falco():
         command = f"timeout {duration} falco"
 
         if config_file:
-            command += f" --config {config_file}"
+            command += f" -c {config_file}"
 
         if rules_file:
-            command += f" --rules {rules_file}"
+            command += f" -r {rules_file}"
 
         if output_format == "json":
             command += " --json"
@@ -10989,7 +11093,7 @@ def nikto():
     """Execute nikto with enhanced logging"""
     try:
         params = request.json
-        target = params.get("target", "")
+        target = (params.get("target") or "").strip()
         additional_args = params.get("additional_args", "")
 
         if not target:
@@ -11686,19 +11790,21 @@ def enum4linux_ng():
         if domain:
             command += f" -d {domain}"
 
-        # Add specific enumeration options
-        enum_options = []
-        if shares:
-            enum_options.append("S")
-        if users:
-            enum_options.append("U")
-        if groups:
-            enum_options.append("G")
-        if policy:
-            enum_options.append("P")
+        enum_flags = []
 
-        if enum_options:
-            command += f" -A {','.join(enum_options)}"
+        if shares:
+            enum_flags.append("-S")
+        if users:
+            enum_flags.append("-U")
+        if groups:
+            enum_flags.append("-G")
+        if policy:
+            enum_flags.append("-P")
+
+        if enum_flags:
+            command += " " + " ".join(enum_flags)
+        else:
+            command += " -A"
 
         if additional_args:
             command += f" {additional_args}"
@@ -12278,7 +12384,7 @@ def ghidra():
             command += f" -postScript {script_file}"
 
         if output_format == "xml":
-            command += f" -postScript ExportXml.java {project_dir}/analysis.xml"
+            command += f" -postScript ExportProgramScript.java {project_dir}/analysis.xml true"
 
         if additional_args:
             command += f" {additional_args}"
@@ -12710,7 +12816,7 @@ def dotdotpwn():
     """Execute DotDotPwn for directory traversal testing with enhanced logging"""
     try:
         params = request.json
-        target = params.get("target", "")
+        target = (params.get("target") or "").strip()
         module = params.get("module", "http")
         additional_args = params.get("additional_args", "")
 
@@ -12720,10 +12826,50 @@ def dotdotpwn():
                 "error": "Target parameter is required"
             }), 400
 
-        command = f"dotdotpwn -m {module} -h {target}"
+        host = target
+        port = None
+
+        if "://" in host:
+            parsed = urlparse(host)
+            host = parsed.hostname or host
+            port = parsed.port
+            if port is None:
+                if parsed.scheme == "https":
+                    port = 443
+                elif parsed.scheme == "http":
+                    port = 80
+        else:
+            host_part = host.split("/", 1)[0]
+            if ":" in host_part:
+                candidate_host, candidate_port = host_part.rsplit(":", 1)
+                if candidate_port.isdigit():
+                    host = candidate_host
+                    port = int(candidate_port)
+                else:
+                    host = host_part
+            else:
+                host = host_part
+
+        command = f"dotdotpwn -m {module}"
+
+        if module == "http-url":
+            url = target or ""
+            if "TRAVERSAL" not in url.upper():
+                separator = "&" if "?" in url else ("" if url.endswith("TRAVERSAL") else "?")
+                url = f"{url}{separator}TRAVERSAL"
+            command += f" -u {url}"
+            if url.lower().startswith("https://") and (not additional_args or " -S" not in additional_args):
+                command += " -S"
+        else:
+            command += f" -h {host}"
+
+        has_port_flag = bool(additional_args and re.search(r"(^|\s)(-x)\b", additional_args))
 
         if additional_args:
             command += f" {additional_args}"
+
+        if port and not has_port_flag and module != "http-url":
+            command += f" -x {port}"
 
         command += " -b"
 
@@ -13138,6 +13284,8 @@ def httpx():
     try:
         params = request.json
         target = params.get("target", "")
+        target_file = params.get("target_file", "")
+        url = params.get("url", "")
         probe = params.get("probe", True)
         tech_detect = params.get("tech_detect", False)
         status_code = params.get("status_code", False)
@@ -13147,11 +13295,18 @@ def httpx():
         threads = params.get("threads", 50)
         additional_args = params.get("additional_args", "")
 
-        if not target:
+        # Accept either a list file (-l) or a single URL (-u)
+        if target_file:
+            command = f"httpx -l {target_file} -t {threads}"
+        elif target and (target.startswith("http://") or target.startswith("https://")):
+            command = f"httpx -u {target} -t {threads}"
+        elif target:
+            command = f"httpx -l {target} -t {threads}"
+        elif url:
+            command = f"httpx -u {url} -t {threads}"
+        else:
             logger.warning("🌐 httpx called without target parameter")
-            return jsonify({"error": "Target parameter is required"}), 400
-
-        command = f"httpx -l {target} -t {threads}"
+            return jsonify({"error": "Target parameter is required (target_file or target/url)"}), 400
 
         if probe:
             command += " -probe"
@@ -14221,6 +14376,110 @@ def browser_agent_endpoint():
         )
         return jsonify({"error": f"Server error: {str(e)}"}), 500
 
+@app.route("/api/tools/burpsuite", methods=["POST"])
+def burpsuite():
+    """Execute Burp Suite with enhanced logging; fallback to alternative workflow when CLI unsupported."""
+    try:
+        params = request.json or {}
+
+        project_file = params.get("project_file", "")
+        config_file = params.get("config_file", "")
+        target = params.get("target", "")
+        headless = params.get("headless", False)
+        scan_type = params.get("scan_type", "")
+        scan_config = params.get("scan_config", "")
+        output_file = params.get("output_file", "")
+        additional_args = params.get("additional_args", "")
+
+        if not target:
+            logger.warning("🎯 Burp Suite called without target parameter")
+            return jsonify({"error": "Target parameter is required"}), 400
+
+        command_parts = ["burpsuite"]
+
+        if headless:
+            command_parts.append("--headless")
+
+        if project_file:
+            command_parts.append(f'--project-file "{project_file}"')
+
+        if config_file:
+            command_parts.append(f'--config-file "{config_file}"')
+
+        if scan_type:
+            command_parts.append(f'--scan-type "{scan_type}"')
+
+        if scan_config:
+            command_parts.append(f'--scan-config "{scan_config}"')
+
+        command_parts.append(f'--scan-url "{target}"')
+
+        if output_file:
+            command_parts.append(f'--report-file "{output_file}"')
+
+        if additional_args:
+            command_parts.append(additional_args)
+
+        command = " ".join(command_parts)
+
+        logger.info(
+            f"{ModernVisualEngine.create_section_header('BURP SUITE', '🛡️', 'ORANGE_RED')}"
+        )
+        logger.info(
+            f"{ModernVisualEngine.format_tool_status('BurpSuite', 'RUNNING', target)}"
+        )
+
+        tool_params = {
+            "project_file": project_file,
+            "config_file": config_file,
+            "target": target,
+            "headless": headless,
+            "scan_type": scan_type,
+            "scan_config": scan_config,
+            "output_file": output_file,
+            "additional_args": additional_args,
+        }
+
+        result = execute_command_with_recovery(
+            "burpsuite", command, tool_params, use_cache=False
+        )
+
+        if result.get("success"):
+            logger.info(
+                f"{ModernVisualEngine.format_tool_status('BurpSuite', 'SUCCESS', target)}"
+            )
+            return jsonify(result)
+
+        stdout = result.get("stdout", "")
+        stderr = result.get("stderr", "")
+        fallback_triggers = [
+            "Unrecognized command-line argument",
+            "Do you accept the terms and conditions",
+        ]
+
+        if any(trigger in stdout for trigger in fallback_triggers):
+            logger.warning(
+                f"{ModernVisualEngine.format_tool_status('BurpSuite', 'RECOVERY', 'CLI unsupported, using alternative workflow')}"
+            )
+            fallback_params = params.copy()
+            with app.test_request_context(
+                "/api/tools/burpsuite-alternative",
+                method="POST",
+                json=fallback_params,
+            ):
+                logger.warning("⚠️ Burp Suite CLI unsupported – falling back to alternative workflow")
+                return burpsuite_alternative()
+
+        logger.error(
+            f"{ModernVisualEngine.format_error_card('ERROR', 'BurpSuite', stderr or 'Unknown error')}"
+        )
+        return jsonify(result), 500
+
+    except Exception as e:
+        logger.error(f"💥 Error in burpsuite endpoint: {str(e)}")
+        return jsonify({"error": f"Server error: {str(e)}"}), 500
+
+
 @app.route("/api/tools/burpsuite-alternative", methods=["POST"])
 def burpsuite_alternative():
     """Comprehensive Burp Suite alternative combining HTTP framework and browser agent"""
@@ -14354,6 +14613,77 @@ def zap():
 
         if additional_args:
             command += f" {additional_args}"
+
+        if daemon:
+            # Idempotent non-blocking start with readiness probe
+            try:
+                with socket.create_connection((host, int(port)), timeout=0.5):
+                    logger.info(f"ZAP already listening on {host}:{port}")
+                    return jsonify({
+                        "stdout": f"ZAP already running on {host}:{port}",
+                        "stderr": "",
+                        "return_code": 0,
+                        "success": True,
+                        "timed_out": False,
+                        "partial_results": False,
+                        "execution_time": 0,
+                        "timestamp": datetime.now().isoformat()
+                    })
+            except Exception:
+                pass
+
+            logger.info(f"Starting ZAP daemon on {host}:{port}")
+            try:
+                subprocess.Popen(
+                    command,
+                    shell=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL
+                )
+            except Exception as e:
+                logger.error(f"Failed to start ZAP daemon: {e}")
+                return jsonify({
+                    "stdout": "",
+                    "stderr": str(e),
+                    "return_code": 1,
+                    "success": False,
+                    "timed_out": False,
+                    "partial_results": False,
+                    "execution_time": 0,
+                    "timestamp": datetime.now().isoformat()
+                }), 500
+
+            start_ts = time.time()
+            deadline = start_ts + 30.0
+            while time.time() < deadline:
+                try:
+                    with socket.create_connection((host, int(port)), timeout=0.5):
+                        exec_time = time.time() - start_ts
+                        logger.info(f"ZAP daemon is ready on {host}:{port} in {exec_time:.2f}s")
+                        return jsonify({
+                            "stdout": f"ZAP listening on {host}:{port}",
+                            "stderr": "",
+                            "return_code": 0,
+                            "success": True,
+                            "timed_out": False,
+                            "partial_results": False,
+                            "execution_time": exec_time,
+                            "timestamp": datetime.now().isoformat()
+                        })
+                except Exception:
+                    time.sleep(0.5)
+
+            logger.warning(f"ZAP daemon not ready after 30s on {host}:{port}")
+            return jsonify({
+                "stdout": "",
+                "stderr": f"ZAP did not become ready on {host}:{port} within 30s",
+                "return_code": 124,
+                "success": False,
+                "timed_out": True,
+                "partial_results": False,
+                "execution_time": 30.0,
+                "timestamp": datetime.now().isoformat()
+            })
 
         logger.info(f"🔍 Starting ZAP scan: {target}")
         result = execute_command(command)


### PR DESCRIPTION
> Priority request: please consider this with high priority. A shared Docker workflow and MCP hardening give the community a stable, identical environment for running tools and for further testing.

## Summary

This PR adds an official Docker packaging and strengthens the MCP client and server so AI assistants run reliably across environments, including strict STDIO fallback for ChatGPT Codex and consistent wrappers for common tools.

## Rationale

* Reproducibility: one image and compose stack so contributors and AIs run the same toolchain.
* Reliability: stdio bootstrap avoids Codex startup hangs; command timeouts prevent long locks; wildcard handling reduces noisy outputs.
* Consistency: unified httpx semantics, sane defaults for cloud tooling, and de-duplicated health reporting.

## What changed

### Docker packaging

* New `docker/` directory with a multi-stage Dockerfile based on Kali Linux and helper scripts to build and run the server.
* `docker-compose.yml` includes host networking, privileged default, bind-mounted caches, health check, and sidecars for **Clair 4.8.0** and **PostgreSQL 18** with health checks and persistent volumes.
* Helper scripts:

  * `./docker/build-docker-image.sh`
  * `./docker/build-docker-image-release.sh` (no-cache/squash release builds)
  * `./docker/start-docker-mcp-server.sh`
* A patched `ghidra/ExportProgramScript.java` is copied into the image to avoid the upstream NPE during export.

### MCP client (`hexstrike_mcp.py`)

* **STDIO fallback**: when running over stdio, HTTP health probes are skipped and the client starts `run_stdio()` directly, which restores Codex compatibility.
* **Cloud tooling**: `prowler_scan` defaults to `json-ocsf` output format.
* **httpx**: unified wrapper aligned with the server `target_file` semantics and **removed the duplicate variant** that lacked `target_file`.
* **Fixes**: corrected `ai_generate_payload` invocation.

### MCP server (`hexstrike_server.py`)

* **Timeouts**: `execute_command` enforces per-command timeouts with sensible defaults, overridable per tool.
* **Health**: de-duplicates tool inventory for accurate counts and **guards empty worker pools**.
* **Nmap**: parses `host:port` from URLs, strips scheme and path, and passes a clean host to Nmap.
* **Gobuster**: automatic wildcard handling that chooses `--exclude-length` or `--wildcard` as needed.
* **dotdotpwn**: parses explicit ports and falls back to `TRAVERSAL` when mode is omitted.
* **httpx**: endpoint supports `target_file` and aligns flags with the client wrapper.
* **Burp Suite**: new `/api/tools/burpsuite` with automatic fallback to the alternative path when Community Edition refuses headless mode.
* **ZAP**: daemon readiness probe so the API returns only after the service is ready.
* **Prowler**: default output format set to `json-ocsf` for consistency with the client.

### Documentation

* README gains a "Docker Installation" section with rationale, quick start, cache notes, and a health check example.
* `.gitignore` excludes local env, logs, and cache directories created by the Docker workflow.

## Testing

```bash
# 1) Clone
git clone https://github.com/0x4m4/hexstrike-ai.git
cd hexstrike-ai

# 2) Build image (dev)
./docker/build-docker-image.sh

# 2b) Build image (release)
./docker/build-docker-image-release.sh

# 3) Start MCP server
./docker/start-docker-mcp-server.sh

# 4) Verify
curl http://localhost:8888/health
```

* AI clients: ChatGPT Codex (stdio fallback verified), Claude Desktop (stdio) with repeated runs.
* Targets: OWASP Juice Shop, DVWA, and WordPress to validate wildcard handling, `host:port` parsing, httpx `target_file`, Burp fallback, and general stability.
* Cloud tools: Prowler, Pacu, CloudMapper smoke-tested without real credentials.

## Backward compatibility

* Removal of the duplicate httpx variant may require downstream users to switch to the unified endpoint.
* Defaults are conservative and can be overridden.

## Linked issues

Closes #93
Closes #88
Relates to #78, #84, #85, #77, #81
