### PR TITLE
Fix graphql_scanner False positive & httpx integration broken

### DIFF
--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -13151,7 +13151,7 @@ def httpx():
             logger.warning("🌐 httpx called without target parameter")
             return jsonify({"error": "Target parameter is required"}), 400
 
-        command = f"httpx -l {target} -t {threads}"
+        command = f"$(go env GOPATH)/bin/httpx -l {target} -t {threads}"
 
         if probe:
             command += " -probe"


### PR DESCRIPTION
The graph_scanner contains the False positive

POC:

```python
└─$ cat test.py
import requests

print("--- testing 404 status_code and no body")
r = requests.post("http://localhost:8888/api/tools/graphql_scanner", json={
  "endpoint": "https://graphql.coinbase.com",
  "introspection": True,
  "query_depth": 20,
  "test_mutations": True
})
print(r.json())

r = requests.post("https://graphql.coinbase.com")
print(r.status_code, r.text)
print()
print("--- testing body contain data text")


r = requests.post("http://localhost:8888/api/tools/graphql_scanner", json={
  "endpoint": "https://vincent55.tw",
  "introspection": True,
  "query_depth": 20,
  "test_mutations": True
})
print(r.json())

r = requests.post("https://vincent55.tw")
print(r.status_code, r.text[:30])
print('data' in r.text)
```


```
└─$ python3 test.py
--- testing 404 status_code and no body
{'graphql_scan_results': {'endpoint': 'https://graphql.coinbase.com', 'recommendations': ['Disable introspection in production', 'Implement query depth limiting', 'Add rate limiting for batch queries', 'Implement query complexity analysis', 'Add authentication for sensitive operations'], 'tests_performed': ['introspection_query', 'query_depth_analysis', 'batch_query_testing'], 'vulnerabilities': [{'description': 'No query depth limiting detected (tested depth: 20)', 'severity': 'HIGH', 'type': 'no_query_depth_limit'}]}, 'success': True}
404

--- testing body contain data text
{'graphql_scan_results': {'endpoint': 'https://vincent55.tw', 'recommendations': ['Disable introspection in production', 'Implement query depth limiting', 'Add rate limiting for batch queries', 'Implement query complexity analysis', 'Add authentication for sensitive operations'], 'tests_performed': ['introspection_query', 'query_depth_analysis', 'batch_query_testing'], 'vulnerabilities': [{'description': 'GraphQL introspection is enabled', 'severity': 'MEDIUM', 'type': 'introspection_enabled'}, {'description': 'No query depth limiting detected (tested depth: 20)', 'severity': 'HIGH', 'type': 'no_query_depth_limit'}, {'description': 'Batch queries are allowed without rate limiting', 'severity': 'MEDIUM', 'type': 'batch_queries_allowed'}]}, 'success': True}
403 <!DOCTYPE html>
<!--

Hello
True
```

After this PR:
- Introspection: now parses stdout as JSON and only reports introspection_enabled when `data.__schema` exists, instead of just checking for the "data" substring.
- Depth check: only evaluates `no_query_depth_limit` if the response is valid GraphQL JSON (data or errors present) and does not contain common mitigation keywords (maximum query, complexity, depth, rate limit, not supported, etc.).
- Batch check: only reports `batch_queries_allowed` when the response is a JSON array of length 10 with at least one element containing data; the old "data" in stdout and success fallback was removed.
- As a result, non-GraphQL or HTML endpoints (e.g. normal websites / 404 pages) no longer produce false-positive GraphQL findings.

