### PR TITLE
Adding Auth Basic header to mcp client for server to site in front of…

### DIFF
--- a/hexstrike_mcp.py
+++ b/hexstrike_mcp.py
@@ -148,7 +148,7 @@ MAX_RETRIES = 3  # Maximum number of retries for connection attempts
 class HexStrikeClient:
     """Enhanced client for communicating with the HexStrike AI API Server"""
 
-    def __init__(self, server_url: str, timeout: int = DEFAULT_REQUEST_TIMEOUT, auth_basic: str = "", verify_ssl: bool = True):
+    def __init__(self, server_url: str, timeout: int = DEFAULT_REQUEST_TIMEOUT, auth_basic: str = "", auth_token: str = "", verify_ssl: bool = True):
         """
         Initialize the HexStrike AI Client
 
@@ -156,6 +156,7 @@ class HexStrikeClient:
             server_url: URL of the HexStrike AI API Server
             timeout: Request timeout in seconds
             auth_basic: Basic authentication credentials in "username:password" format
+            auth_token: Bearer token for authentication
             verify_ssl: Whether to verify SSL certificates
         """
         self.server_url = server_url.rstrip("/")
@@ -164,6 +165,11 @@ class HexStrikeClient:
 
         if not verify_ssl:
             self.session.verify = False  # Disable SSL verification for self-signed certs
+
+        if auth_token:
+            self.session.headers.update({
+                "Authorization": f"Bearer {auth_token}"
+            })
 
         if auth_basic:
             encoded_credentials = base64.b64encode(auth_basic.encode()).decode()
@@ -5435,6 +5441,8 @@ def parse_args():
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument("--auth-basic", type=str, default="",
                       help="Username:password for authentication with HexStrike AI server in front of reverse proxies")
+    parser.add_argument("--auth-token", type=str, default="",
+                      help="Bearer token for authentication with HexStrike AI server")
     parser.add_argument("--disable-ssl-verify", action="store_true", help="Disable SSL certificate verification when connecting to the HexStrike AI server in front of reverse proxies")
     return parser.parse_args()
 
@@ -5451,13 +5459,20 @@ def main():
     logger.info(f"🚀 Starting HexStrike AI MCP Client v6.0")
     logger.info(f"🔗 Connecting to: {args.server}")
 
+    auth_basic = args.auth_basic if args.auth_basic else ""
+    auth_token = args.auth_token if args.auth_token else ""
+
+    if args.auth_basic and args.auth_token:
+        logger.warning("⚠️  Both basic auth and token auth provided - token auth will take precedence")
+        auth_basic = ""
+
     try:
         # Initialize the HexStrike AI client
         verify_ssl = True
         if args.disable_ssl_verify:
             verify_ssl = False
 
-        hexstrike_client = HexStrikeClient(args.server, args.timeout, auth_basic=args.auth_basic, verify_ssl=verify_ssl)
+        hexstrike_client = HexStrikeClient(args.server, args.timeout, auth_basic=auth_basic, auth_token=auth_token, verify_ssl=verify_ssl)
 
         # Check server health and log the result
         health = hexstrike_client.check_health()

--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -39,7 +39,7 @@ import shutil
 import venv
 import zipfile
 from pathlib import Path
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, abort
 import psutil
 import signal
 import requests
@@ -97,6 +97,7 @@ app.config['JSON_SORT_KEYS'] = False
 # API Configuration
 API_PORT = int(os.environ.get('HEXSTRIKE_PORT', 8888))
 API_HOST = os.environ.get('HEXSTRIKE_HOST', '127.0.0.1')
+API_TOKEN = os.environ.get("HEXSTRIKE_API_TOKEN", None)  # e.g. export API_TOKEN=secret-token
 
 # ============================================================================
 # MODERN VISUAL ENGINE (v2.0 ENHANCEMENT)
@@ -9019,6 +9020,22 @@ class FileOperationsManager:
 file_manager = FileOperationsManager()
 
 # API Routes
+
+@app.before_request
+def optional_bearer_auth():
+    # If no token is configured, allow all requests
+    if not API_TOKEN:
+        return
+
+    auth_header = request.headers.get("Authorization", "")
+    prefix = "Bearer "
+
+    if not auth_header.startswith(prefix):
+        abort(401, description="Unexpected authorization header format")
+
+    token = auth_header[len(prefix):]
+    if token != API_TOKEN:
+        abort(401, description="Unauthorized!")
 
 @app.route("/health", methods=["GET"])
 def health_check():


### PR DESCRIPTION
update to hexstrike_mcp.py 

Adding Auth Basic --auth-basic and TLS --disable-ssl-verify flag  to mcp client for servers behind a reverse proxy with auth. 

edit: - Added --auth-token client and code to mcp server to check to token header. 


User can setup a reverse proxy win nginx container. 

```bash
mkdir nginx
cd nginx

podman run -it --rm -v "./nginx/auth:/auth" docker.io/httpd bash -c "htpasswd -c /auth/users hexmin"

cat <<EOF > container-compose.yml 
services:

  nginx:
    hostname: nginx
    container_name: nginx
    image: docker.io/nginx
    pull_policy: always
    network_mode: host
    restart: always
    ports:
      - 8080:8888
    volumes:
      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
      - ./nginx/users:/etc/nginx/auth/users:ro
      - ./nginx/certs:/etc/nginx/ssl:ro
      - ./nginx/logs:/var/log/nginx
EOF

cat <<EOF > nginx.conf
events {
    worker_connections 2048;
}


http {

# Needed for the $connection_upgrade variable
map $http_upgrade $connection_upgrade {
  default upgrade;
    ''      close;
}

    upstream hexstrike {
        server               127.0.0.1:8888;
    }

    keepalive_timeout 300s;

    access_log /var/log/nginx/access.log;
    error_log /var/log/nginx/error.log info;

    server {
        listen              8080 ssl;
        http2 on; 
        server_name example.local;

        ssl_certificate     /etc/nginx/ssl/selfsigned.crt;
        ssl_certificate_key /etc/nginx/ssl/selfsigned.key;

        # Reasonable TLS settings (works broadly)
        ssl_session_cache shared:SSL:10m;
        ssl_session_timeout 10m;
        ssl_protocols TLSv1.2 TLSv1.3;
        ssl_prefer_server_ciphers off;

        # Basic authentication based on the $authentication variable 
        # If using app level token keep comment out 
        #auth_basic "Restricted Area";
        #auth_basic_user_file /etc/nginx/auth/users;
        
        location / {
            proxy_http_version 1.1;
            proxy_buffering off; #
            proxy_set_header  Host "localhost";
            proxy_set_header  X-Real-IP "127.0.0.1";
            proxy_set_header  X-Forwarded-For "127.0.0.1";
            proxy_set_header  X-Forwarded-Proto $scheme;
            proxy_set_header  Connection "";
            proxy_read_timeout 300;
            proxy_connect_timeout 300;
            proxy_send_timeout 300;
            proxy_pass        http://hexstrike;  # Forward request to the actual web service
        }
    }
}
EOF

mkdir certs
openssl req -x509 -nodes -newkey rsa:2048 \
  -keyout certs/selfsigned.key \ 
  -out certs/selfsigned.crt \ 
  -days 365 \
  -subj "/C=US/ST=NY/L=NewYork/O=LocalDev/OU=IT/CN=example.local" \
  -addext "subjectAltName=DNS:example.local,DNS:localhost,IP:127.0.0.1"

cd ..
podman-compose up -d 


hexstrike_server.py # should be on localhost:8888 

hexstrike_mcp.py --server https://x.x.x.x:8080 --auth-basic hexmin:asdfasdf --disable-ssl-verify
```

update to hexstrike_server.py
update host to use API_HOST variable to use localhost as default.

If users want to have the mcp server to bind to all IPs on the host. 
`export HEXSTRIKE_HOST=0.0.0.0`

#122 
#124 