### PR TITLE
Add .gitignore for venv, logs, and local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Virtual environments
+hexstrike-env/
+venv/
+env/
+.venv/
+*.env
+
+# Logs
+*.log
+hexstrike.log
+hexstrike_server.log
+
+# Python cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Local secrets / environment
+.env
+.env.local
+
+# Claude Code local settings
+.claude/settings.local.json
+
+# OS artifacts
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Changes

Added a comprehensive `.gitignore` file to exclude:
- Virtual environment directories (`venv/`, `env/`, `.venv/`, `hexstrike-env/`)
- Log files (`*.log`, `hexstrike.log`, `hexstrike_server.log`)
- Python cache and compiled files (`__pycache__/`, `*.pyc`, `*.pyo`, etc.)
- Distribution and packaging artifacts (`dist/`, `build/`, `*.egg-info/`)
- Local environment and secret files (`.env`, `.env.local`)
- Claude Code local settings (`.claude/settings.local.json`)
- OS-specific artifacts (`.DS_Store`, `Thumbs.db`)

This prevents accidental commits of development artifacts, dependencies, and sensitive configuration files.