### PR TITLE
fix: prevent path traversal in FileOperationsManager sandbox (CWE-22)

### DIFF
--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -8929,14 +8929,44 @@ class FileOperationsManager:
     """Handle file operations with security and validation"""
 
     def __init__(self, base_dir: str = "/tmp/hexstrike_files"):
-        self.base_dir = Path(base_dir)
+        self.base_dir = Path(base_dir).resolve()
         self.base_dir.mkdir(exist_ok=True)
         self.max_file_size = 100 * 1024 * 1024  # 100MB
+
+    def _validate_path(self, filename: str) -> 'Path':
+        """Validate and resolve a file path, ensuring it stays within the sandbox.
+
+        Prevents path traversal attacks (CWE-22) by resolving the full
+        canonical path (following symlinks) and verifying it remains under
+        base_dir. Raises ValueError on any escape attempt.
+        """
+        # Reject absolute paths outright
+        if Path(filename).is_absolute():
+            raise ValueError("Absolute paths are not allowed")
+
+        # Reject null bytes which can truncate paths in some OS APIs
+        if "\x00" in filename:
+            raise ValueError("Null bytes are not allowed in filenames")
+
+        # Resolve to canonical absolute path (resolves .., symlinks, etc.)
+        resolved = (self.base_dir / filename).resolve()
+
+        # Ensure the resolved path is within the sandbox directory.
+        # Using Path.relative_to() which raises ValueError if not a subpath,
+        # avoiding prefix false-positives (e.g. /tmp/hexstrike_files_evil).
+        try:
+            resolved.relative_to(self.base_dir)
+        except ValueError:
+            raise ValueError(
+                "Path traversal detected: resolved path escapes sandbox directory"
+            )
+
+        return resolved
 
     def create_file(self, filename: str, content: str, binary: bool = False) -> Dict[str, Any]:
         """Create a file with the specified content"""
         try:
-            file_path = self.base_dir / filename
+            file_path = self._validate_path(filename)
             file_path.parent.mkdir(parents=True, exist_ok=True)
 
             if len(content.encode()) > self.max_file_size:
@@ -8959,7 +8989,7 @@ class FileOperationsManager:
     def modify_file(self, filename: str, content: str, append: bool = False) -> Dict[str, Any]:
         """Modify an existing file"""
         try:
-            file_path = self.base_dir / filename
+            file_path = self._validate_path(filename)
             if not file_path.exists():
                 return {"success": False, "error": "File does not exist"}
 
@@ -8977,7 +9007,7 @@ class FileOperationsManager:
     def delete_file(self, filename: str) -> Dict[str, Any]:
         """Delete a file or directory"""
         try:
-            file_path = self.base_dir / filename
+            file_path = self._validate_path(filename)
             if not file_path.exists():
                 return {"success": False, "error": "File does not exist"}
 
@@ -8996,7 +9026,7 @@ class FileOperationsManager:
     def list_files(self, directory: str = ".") -> Dict[str, Any]:
         """List files in a directory"""
         try:
-            dir_path = self.base_dir / directory
+            dir_path = self._validate_path(directory)
             if not dir_path.exists():
                 return {"success": False, "error": "Directory does not exist"}
 


### PR DESCRIPTION
## Summary

Fixes a **path traversal vulnerability (CWE-22)** in `FileOperationsManager` that allows arbitrary file write, modify, delete, and list operations outside the intended sandbox directory (`/tmp/hexstrike_files`).

**Affected methods:** `create_file()`, `modify_file()`, `delete_file()`, `list_files()`

**Attack vector:** Supplying filenames containing `../` sequences or symlinks pointing outside the sandbox (e.g. `../../../var/www/html/shell.php`).

**Impact:** Arbitrary file write leading to RCE via web shell injection, SSH key hijacking, cron job exploitation, or system configuration tampering.

## Fix

Added a `_validate_path()` method that enforces sandbox boundaries on all file operations:

1. **Rejects absolute paths** — prevents direct path specification like `/etc/passwd`
2. **Rejects null bytes** — prevents path truncation attacks in OS APIs
3. **Resolves canonical paths** — uses `Path.resolve()` to normalize `..` sequences and follow symlinks before validation
4. **Verifies containment** — uses `Path.relative_to()` to confirm the resolved path is under `base_dir`, avoiding prefix false-positives (e.g. `/tmp/hexstrike_files_evil` would not match `/tmp/hexstrike_files`)
5. **Resolves base_dir at init** — `self.base_dir` is now stored as its resolved canonical path to prevent TOCTOU issues

All four public methods (`create_file`, `modify_file`, `delete_file`, `list_files`) now call `_validate_path()` before any filesystem operation. `ValueError` exceptions from validation are caught by existing `except Exception` handlers and returned as error responses.

## Test Results

Validated against the following attack vectors:

| Input | Result |
|-------|--------|
| `normal.txt` | Allowed |
| `subdir/file.txt` | Allowed |
| `../../../tmp/shell.php` | **Blocked** |
| `../../../var/www/html/shell.php` | **Blocked** |
| `foo/../../bar/../../../etc/passwd` | **Blocked** |
| `/etc/passwd` | **Blocked** |
| Symlink escaping sandbox | **Blocked** |

Closes #135