### PR TITLE
Add Codex CLI plugin manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "hexstrike-ai",
+  "version": "0.1.0",
+  "description": "Run 150+ cybersecurity tools from Codex via MCP",
+  "author": {
+    "name": "0x4m4",
+    "url": "https://github.com/0x4m4/hexstrike-ai"
+  },
+  "homepage": "https://github.com/0x4m4/hexstrike-ai",
+  "repository": "https://github.com/0x4m4/hexstrike-ai",
+  "keywords": [
+    "mcp",
+    "security",
+    "pentesting",
+    "codex"
+  ],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "HexStrike AI",
+    "shortDescription": "150+ cybersecurity tools for Codex via MCP",
+    "category": "Security",
+    "websiteURL": "https://github.com/0x4m4/hexstrike-ai"
+  },
+  "skills": "./skills/"
+}

--- a/.github/workflows/plugin-quality-gate.yml
+++ b/.github/workflows/plugin-quality-gate.yml
@@ -1,0 +1,20 @@
+name: Plugin Quality Gate
+
+on:
+  pull_request:
+    paths:
+      - ".codex-plugin/**"
+      - "skills/**"
+      - ".mcp.json"
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin quality gate
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+          min_score: 80
+          fail_on_severity: high

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "hexstrike-ai": {
+      "command": "python",
+      "args": [
+        "server.py"
+      ]
+    }
+  }
+}

--- a/skills/hexstrike-ai/SKILL.md
+++ b/skills/hexstrike-ai/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: hexstrike-ai
+description: Run 150+ cybersecurity tools from Codex.
+---
+
+# HexStrike AI for Codex
+
+Run cybersecurity tools through HexStrike MCP. See https://github.com/0x4m4/hexstrike-ai for setup.


### PR DESCRIPTION
Adds a Codex CLI plugin manifest for HexStrike AI.

**What this adds:** .codex-plugin/plugin.json, .mcp.json, skills/hexstrike-ai/SKILL.md

**Related:** [awesome-codex-plugins](https://github.com/internet-dot/awesome-codex-plugins) | [codex-plugin-scanner](https://github.com/hashgraph-online/ai-plugin-scanner)