### PR TITLE
fix(security): bind API to 127.0.0.1 by default and warn on wildcard binding

### DIFF
--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -17260,6 +17260,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run the HexStrike AI API Server")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
     parser.add_argument("--port", type=int, default=API_PORT, help=f"Port for the API server (default: {API_PORT})")
+    parser.add_argument("--host", type=str, default=API_HOST, help=f"Host interface to bind (default: {API_HOST}). Use 0.0.0.0 to expose on all interfaces (NOT RECOMMENDED — the API has no authentication).")
     args = parser.parse_args()
 
     if args.debug:
@@ -17268,6 +17269,9 @@ if __name__ == "__main__":
 
     if args.port != API_PORT:
         API_PORT = args.port
+
+    if args.host != API_HOST:
+        API_HOST = args.host
 
     # Enhanced startup messages with beautiful formatting
     startup_info = f"""
@@ -17286,4 +17290,19 @@ if __name__ == "__main__":
         if line.strip():
             logger.info(line)
 
-    app.run(host="0.0.0.0", port=API_PORT, debug=DEBUG_MODE)
+    # SECURITY: Warn loudly when binding to a non-loopback interface. The
+    # HexStrike API has no built-in authentication, so binding to 0.0.0.0 (or
+    # any externally reachable interface) exposes every endpoint — including
+    # arbitrary command execution helpers — to the network.
+    if API_HOST in ("0.0.0.0", "::", ""):
+        warning_msg = (
+            "⚠️  SECURITY WARNING: Binding to 0.0.0.0 exposes the unauthenticated "
+            "HexStrike API on all network interfaces. Anyone able to reach this "
+            "host can invoke every endpoint (including command execution). "
+            "Bind to 127.0.0.1 (the default) unless you have placed the server "
+            "behind an authenticating reverse proxy or firewall."
+        )
+        logger.warning(warning_msg)
+        print(f"\n{ModernVisualEngine.COLORS['CRITICAL']}{warning_msg}{ModernVisualEngine.COLORS['RESET']}\n")
+
+    app.run(host=API_HOST, port=API_PORT, debug=DEBUG_MODE)


### PR DESCRIPTION
## Summary

The HexStrike API server currently binds unconditionally to `0.0.0.0`, exposing the unauthenticated API — which includes many endpoints that execute arbitrary tooling/commands on the host — to every network interface by default. This PR changes the default bind to `127.0.0.1`, makes the interface configurable via the existing `HEXSTRIKE_HOST` env var or a new `--host` CLI flag, and prints a loud warning if a wildcard interface is selected.

## Vulnerability details

- **File / function:** `hexstrike_server.py`, `__main__` block (the `app.run(...)` call near the bottom of the file)
- **Class:** insecure default network exposure of an unauthenticated administrative/RCE-capable HTTP API. Often filed as CWE-200 (information exposure); arguably more precisely CWE-668 / CWE-306 (exposure of resource to wrong sphere / missing authentication for critical function).
- **Data flow:** there is no user-input sink here — the issue is the bind address itself. The pre-fix code is:

  ```python
  app.run(host="0.0.0.0", port=API_PORT, debug=DEBUG_MODE)
  ```

  Although `API_HOST` is defined at the top of the file and defaults to `127.0.0.1` (with `HEXSTRIKE_HOST` override), the variable was never actually passed to `app.run()`, so the env var was effectively dead code and the server always listened on all interfaces.

- **Impact:** any host on the same L2/L3 segment (or the public internet, if the machine is internet-facing) can hit the API and trigger the command-execution endpoints without authenticating.

## Fix

Minimal, surgical change in the `__main__` block only:

1. Add a `--host` CLI argument that defaults to the existing `API_HOST` global (which itself honors `HEXSTRIKE_HOST`).
2. Apply `args.host` to `API_HOST` the same way `args.port` is already applied to `API_PORT`.
3. Pass `host=API_HOST` to `app.run(...)` instead of the hard-coded `"0.0.0.0"`.
4. If the resulting bind address is `0.0.0.0`, `::`, or empty, log a `WARNING` and print a colored notice explaining the risk before the server starts.

Net effect: the default is now loopback-only (the secure default for an unauthenticated tool), and operators who genuinely want network exposure can opt in explicitly via `--host 0.0.0.0` or `HEXSTRIKE_HOST=0.0.0.0`, with a visible warning so the choice is conscious.

Diff is 20 added / 1 removed line in a single file.

## What I tested

- Started the server with no args → bound to `127.0.0.1:8888`, warning not printed. Confirmed with `ss -ltnp`.
- Started with `--host 0.0.0.0` → bound to `0.0.0.0:8888`, warning printed in red and logged at WARNING level.
- Started with `HEXSTRIKE_HOST=0.0.0.0` (no flag) → same behavior as above.
- Started with `--port 9000` (regression check) → still works, picks up the new port.
- `python -c "import ast; ast.parse(open('hexstrike_server.py').read())"` → parses cleanly.

## Why this is exploitable in practice

The only precondition for exploitation is network reachability to the host running `hexstrike_server.py`. There is no auth layer in front of the Flask app, no token check, no allowlist — every route is callable by anonymous clients. Several routes shell out to user-supplied arguments, so reachability ≈ RCE on the host. Given the project's audience (red-team operators who frequently run it on cloud VMs, lab boxes, or shared subnets), the wildcard default has a meaningfully larger blast radius than loopback.

## Adversarial review

Before opening this PR, I tried to talk myself out of it. The main "is this even a bug?" angles I considered: (a) maybe the README tells users to firewall it — it doesn't, and the README's quickstart just runs `python3 hexstrike_server.py` with no network guidance; (b) maybe `HEXSTRIKE_HOST` was already wired through and I missed it — I checked, it's read into `API_HOST` but never passed to `app.run`, so it was a no-op; (c) maybe binding to `0.0.0.0` is intentional because remote MCP clients connect over the network — that's a legitimate use case, which is exactly why this PR keeps the option available behind an explicit flag rather than removing it. The fix changes a default and adds a warning; it does not break any documented workflow.

cc @lewiswigmore
