### PR TITLE
Add Windows startup script (start_server.bat)

### DIFF
--- a/start_server.bat
+++ b/start_server.bat
@@ -1,5 +1,15 @@
 @echo off
+:: HexStrike AI - Windows Server Startup Script
+:: Launches the Flask API server with correct Unicode settings for Windows.
+:: Run this before starting Claude Code or any MCP client that uses HexStrike.
+
 set PYTHONUTF8=1
 set PYTHONIOENCODING=utf-8
+
+:: Resolve paths relative to this script's location
+set SCRIPT_DIR=%~dp0
+set VENV_PYTHON=%SCRIPT_DIR%hexstrike-env\Scripts\python.exe
+set SERVER=%SCRIPT_DIR%hexstrike_server.py
+
 echo Starting HexStrike AI Server on port 8888...
-"C:\Users\Alcapone\Documents\PYTHON\hexstrike-ai\hexstrike-env\Scripts\python.exe" -X utf8 "C:\Users\Alcapone\Documents\PYTHON\hexstrike-ai\hexstrike_server.py"
+"%VENV_PYTHON%" -X utf8 "%SERVER%" %*

--- a/start_server.bat
+++ b/start_server.bat
@@ -1,0 +1,5 @@
+@echo off
+set PYTHONUTF8=1
+set PYTHONIOENCODING=utf-8
+echo Starting HexStrike AI Server on port 8888...
+"C:\Users\Alcapone\Documents\PYTHON\hexstrike-ai\hexstrike-env\Scripts\python.exe" -X utf8 "C:\Users\Alcapone\Documents\PYTHON\hexstrike-ai\hexstrike_server.py"


### PR DESCRIPTION
## Summary

- Add  — a portable Windows batch script for launching the HexStrike AI API server
- Uses -relative paths so it works from any installation directory
- Sets  and  to prevent  on Windows (cp1252 codec cannot encode the emoji characters in the banner and log output)
- Passes  through so CLI flags like  or  still work

## Problem solved

On Windows, running  directly crashes with:



This script fixes that by forcing UTF-8 mode before the process starts.

## Test plan

- [ ] Run  on a fresh Windows machine with the venv set up
- [ ] Confirm the server starts and the banner prints without errors
- [ ] Confirm  passes the flag through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)