### PR TITLE
docs: add community HexStrike guide index

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,22 @@ python3 hexstrike_server.py --port 8888 --debug
 
 ---
 
+## Community Documentation
+
+A community-maintained lab guide covering real-world HexStrike AI usage with Gemini CLI, OpenAI Codex, Cursor MCP, and Ollama — from installation to full Active Directory compromise.
+
+📖 **[HexStrike AI Lab Guide](https://anpa1200.github.io/Hexstrike-AI-guide/)** — by [@anpa1200](https://github.com/anpa1200)
+
+**Covers:**
+- Installation on Kali Linux 2025.4 (package + source)
+- LLM integrations: Gemini CLI · OpenAI Codex · Cursor MCP · Ollama (local/air-gapped)
+- Attack techniques: network, web app, wireless, SSH, SMB, Active Directory, ADCS ESC8, web+cloud
+- Recon & OSINT: Shodan integration · email-to-exposure-map workflows
+- Password recovery: ZIP · PDF · Office documents · WPA2
+- Full PT walkthroughs: lab setup · full subnet compromise · black-box AD engagement
+
+---
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -695,17 +695,49 @@ python3 hexstrike_server.py --port 8888 --debug
 
 ## Community Documentation
 
-A community-maintained lab guide covering real-world HexStrike AI usage with Gemini CLI, OpenAI Codex, Cursor MCP, and Ollama — from installation to full Active Directory compromise.
+A community-maintained, hands-on guide covering HexStrike AI installation, LLM integrations, authorized lab workflows, and end-to-end assessment examples.
 
-📖 **[HexStrike AI Lab Guide](https://anpa1200.github.io/Hexstrike-AI-guide/)** — by [@anpa1200](https://github.com/anpa1200)
+📖 **[HexStrike AI Lab Guide](https://1200km.com/Hexstrike-AI-guide/)** · [Source](https://github.com/anpa1200/Hexstrike-AI-guide) · maintained by [@anpa1200](https://github.com/anpa1200)
 
-**Covers:**
-- Installation on Kali Linux 2025.4 (package + source)
-- LLM integrations: Gemini CLI · OpenAI Codex · Cursor MCP · Ollama (local/air-gapped)
-- Attack techniques: network, web app, wireless, SSH, SMB, Active Directory, ADCS ESC8, web+cloud
-- Recon & OSINT: Shodan integration · email-to-exposure-map workflows
-- Password recovery: ZIP · PDF · Office documents · WPA2
-- Full PT walkthroughs: lab setup · full subnet compromise · black-box AD engagement
+### Getting Started
+
+- [Overview and architecture](https://1200km.com/Hexstrike-AI-guide/docs/getting-started/overview)
+- [Installation on Kali Linux](https://1200km.com/Hexstrike-AI-guide/docs/getting-started/installation)
+- [HexStrike AI compared with other AI security tools](https://1200km.com/Hexstrike-AI-guide/docs/getting-started/vs-other-tools)
+
+### LLM and MCP Integrations
+
+- [Integration overview](https://1200km.com/Hexstrike-AI-guide/docs/llm-integrations/overview)
+- [Gemini CLI](https://1200km.com/Hexstrike-AI-guide/docs/llm-integrations/gemini)
+- [OpenAI Codex](https://1200km.com/Hexstrike-AI-guide/docs/llm-integrations/openai-codex)
+- [Cursor MCP](https://1200km.com/Hexstrike-AI-guide/docs/llm-integrations/cursor-mcp)
+- [Local Ollama orchestration](https://1200km.com/Hexstrike-AI-guide/docs/llm-integrations/ollama-local)
+
+### Reconnaissance and Authorized Attack Labs
+
+- [Shodan reconnaissance](https://1200km.com/Hexstrike-AI-guide/docs/recon-osint/shodan)
+- [Email OSINT and exposure mapping](https://1200km.com/Hexstrike-AI-guide/docs/recon-osint/email-osint)
+- [Network discovery](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/network-discovery)
+- [Web application testing](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/web-application)
+- [Wireless and Wi-Fi testing](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/wireless-wifi)
+- [SSH credential auditing](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/ssh-brute-force)
+- [SMB credential auditing](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/smb-brute-force)
+- [Active Directory assessment](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/active-directory)
+- [AD CS ESC8 lab](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/adcs-esc8)
+- [Web and cloud assessment](https://1200km.com/Hexstrike-AI-guide/docs/attack-techniques/web-cloud)
+
+### Password Recovery and Full Walkthroughs
+
+- [Modern password recovery](https://1200km.com/Hexstrike-AI-guide/docs/password-recovery/modern-cracking)
+- [ZIP recovery](https://1200km.com/Hexstrike-AI-guide/docs/password-recovery/zip)
+- [PDF recovery](https://1200km.com/Hexstrike-AI-guide/docs/password-recovery/pdf)
+- [Office document recovery](https://1200km.com/Hexstrike-AI-guide/docs/password-recovery/office-documents)
+- [Full penetration-testing methodology](https://1200km.com/Hexstrike-AI-guide/docs/full-pt-walkthroughs/full-pt-guide)
+- [Isolated vulnerable lab setup](https://1200km.com/Hexstrike-AI-guide/docs/full-pt-walkthroughs/lab-setup)
+- [Full-subnet assessment walkthrough](https://1200km.com/Hexstrike-AI-guide/docs/full-pt-walkthroughs/full-subnet)
+- [Black-box Active Directory walkthrough](https://1200km.com/Hexstrike-AI-guide/docs/full-pt-walkthroughs/black-box-ad)
+
+> All walkthroughs are documented for isolated labs and explicitly authorized security assessments.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a curated **Community Documentation** section linking to the community-maintained HexStrike AI Lab Guide and its practical guides.

- **Live guide:** https://1200km.com/Hexstrike-AI-guide/
- **Source:** https://github.com/anpa1200/Hexstrike-AI-guide

## Included guide index

| Area | Directly linked guides |
|---|---:|
| Getting started and installation | 3 |
| LLM and MCP integrations | 5 |
| Reconnaissance and authorized attack labs | 10 |
| Password recovery and full walkthroughs | 8 |
| **Total** | **26** |

The index covers Gemini CLI, OpenAI Codex, Cursor MCP, Ollama, Shodan, network/web/wireless testing, Active Directory, AD CS ESC8, password recovery, lab setup, full-subnet assessment, and black-box AD workflows.

## Scope and safety

- Documentation-only change to `README.md`
- No upstream code or dependencies changed
- Walkthroughs explicitly describe isolated labs and authorized assessments
- All 27 linked `1200km.com` pages, including the guide homepage, were validated successfully with HTTP 200 responses on June 14, 2026