### PR TITLE
fix: Windows compatibility, /health blocking, threaded Flask, FastMCP v3 duplicate tool

### DIFF
--- a/hexstrike_mcp.py
+++ b/hexstrike_mcp.py
@@ -2673,12 +2673,12 @@ def setup_mcp_server(hexstrike_client: HexStrikeClient) -> FastMCP:
         return result
 
     @mcp.tool()
-    def httpx_probe(target: str, probe: bool = True, tech_detect: bool = False,
+    def httpx_probe_single(target: str, probe: bool = True, tech_detect: bool = False,
                    status_code: bool = False, content_length: bool = False,
                    title: bool = False, web_server: bool = False, threads: int = 50,
                    additional_args: str = "") -> Dict[str, Any]:
         """
-        Execute httpx for fast HTTP probing and technology detection.
+        Execute httpx for fast HTTP probing and technology detection (single target).
 
         Args:
             target: Target file or single URL

--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -5705,9 +5705,12 @@ class ProcessManager:
 class PythonEnvironmentManager:
     """Manage Python virtual environments and dependencies"""
 
-    def __init__(self, base_dir: str = "/tmp/hexstrike_envs"):
+    def __init__(self, base_dir: str = None):
+        if base_dir is None:
+            import tempfile
+            base_dir = str(Path(tempfile.gettempdir()) / "hexstrike_envs")
         self.base_dir = Path(base_dir)
-        self.base_dir.mkdir(exist_ok=True)
+        self.base_dir.mkdir(exist_ok=True, parents=True)
 
     def create_venv(self, env_name: str) -> Path:
         """Create a new virtual environment"""
@@ -5721,6 +5724,9 @@ class PythonEnvironmentManager:
         """Install a package in the specified environment"""
         env_path = self.create_venv(env_name)
         pip_path = env_path / "bin" / "pip"
+        if not pip_path.exists():
+            # Windows uses Scripts\pip.exe
+            pip_path = env_path / "Scripts" / "pip.exe"
 
         try:
             result = subprocess.run([str(pip_path), "install", package],
@@ -5738,7 +5744,11 @@ class PythonEnvironmentManager:
     def get_python_path(self, env_name: str) -> str:
         """Get Python executable path for environment"""
         env_path = self.create_venv(env_name)
-        return str(env_path / "bin" / "python")
+        python_path = env_path / "bin" / "python"
+        if not python_path.exists():
+            # Windows
+            python_path = env_path / "Scripts" / "python.exe"
+        return str(python_path)
 
 # Global environment manager
 env_manager = PythonEnvironmentManager()
@@ -8928,9 +8938,12 @@ def _determine_operation_type(tool_name: str) -> str:
 class FileOperationsManager:
     """Handle file operations with security and validation"""
 
-    def __init__(self, base_dir: str = "/tmp/hexstrike_files"):
+    def __init__(self, base_dir: str = None):
+        if base_dir is None:
+            import tempfile
+            base_dir = str(Path(tempfile.gettempdir()) / "hexstrike_files")
         self.base_dir = Path(base_dir)
-        self.base_dir.mkdir(exist_ok=True)
+        self.base_dir.mkdir(exist_ok=True, parents=True)
         self.max_file_size = 100 * 1024 * 1024  # 100MB
 
     def create_file(self, filename: str, content: str, binary: bool = False) -> Dict[str, Any]:
@@ -9093,14 +9106,15 @@ def health_check():
         password_tools + binary_tools + forensics_tools + cloud_tools +
         osint_tools + exploitation_tools + api_tools + wireless_tools + additional_tools
     )
-    tools_status = {}
 
-    for tool in all_tools:
-        try:
-            result = execute_command(f"which {tool}", use_cache=True)
-            tools_status[tool] = result["success"]
-        except:
-            tools_status[tool] = False
+    # Cache tools_status for 60s — shutil.which is fast but no need to repeat every call
+    import shutil as _shutil, time as _time
+    _cached = getattr(health_check, "_tools_cache", None)
+    if _cached and (_time.time() - _cached["ts"]) < 60:
+        tools_status = _cached["data"]
+    else:
+        tools_status = {tool: (_shutil.which(tool) is not None) for tool in all_tools}
+        setattr(health_check, "_tools_cache", {"data": tools_status, "ts": _time.time()})
 
     all_essential_tools_available = all(tools_status[tool] for tool in essential_tools)
 
@@ -17286,4 +17300,4 @@ if __name__ == "__main__":
         if line.strip():
             logger.info(line)
 
-    app.run(host="0.0.0.0", port=API_PORT, debug=DEBUG_MODE)
+    app.run(host="0.0.0.0", port=API_PORT, debug=DEBUG_MODE, threaded=True)

--- a/start_hexstrike.py
+++ b/start_hexstrike.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+HexStrike AI Startup Wrapper
+============================
+Auto-starts hexstrike_server.py if not running, then launches hexstrike_mcp.py.
+Used as the MCP command in mcp.json so Kiro always has a running server.
+"""
+
+import os
+import sys
+import subprocess
+import time
+import requests
+import argparse
+
+SERVER_URL = "http://127.0.0.1:8888"
+SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "hexstrike_server.py")
+MCP_SCRIPT = os.path.join(os.path.dirname(__file__), "hexstrike_mcp.py")
+STARTUP_TIMEOUT = 60  # seconds to wait for server to come up
+
+
+def is_server_running(url: str = SERVER_URL, timeout: int = 2) -> bool:
+    try:
+        r = requests.get(f"{url}/health", timeout=timeout)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+def kill_stale_server(port: int = 8888):
+    """Kill any existing process listening on the server port."""
+    import subprocess, sys
+    try:
+        result = subprocess.run(
+            ["netstat", "-ano"],
+            capture_output=True, text=True, timeout=5
+        )
+        for line in result.stdout.splitlines():
+            if f":{port}" in line and "LISTENING" in line:
+                parts = line.split()
+                pid = int(parts[-1])
+                if pid and pid != os.getpid():
+                    try:
+                        subprocess.run(["taskkill", "/F", "/PID", str(pid)],
+                                       capture_output=True, timeout=5)
+                    except Exception:
+                        pass
+    except Exception:
+        pass
+
+
+def start_server():
+    """Start hexstrike_server.py in background."""
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUTF8"] = "1"
+
+    proc = subprocess.Popen(
+        [sys.executable, SERVER_SCRIPT],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
+    )
+    return proc
+
+
+def wait_for_server(timeout: int = STARTUP_TIMEOUT) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if is_server_running():
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="HexStrike AI Startup Wrapper")
+    parser.add_argument("--server", default=SERVER_URL)
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--debug", action="store_true")
+    args, extra = parser.parse_known_args()
+
+    # Override server URL if passed
+    server_url = args.server
+
+    # 1. Check if server already up
+    if not is_server_running(server_url):
+        sys.stderr.write("[hexstrike-wrapper] Server not running, starting hexstrike_server.py...\n")
+        kill_stale_server()  # clean up any zombie instances on port first
+        start_server()
+        if not wait_for_server():
+            sys.stderr.write("[hexstrike-wrapper] ERROR: Server failed to start within timeout!\n")
+            sys.exit(1)
+        sys.stderr.write("[hexstrike-wrapper] Server is up.\n")
+    else:
+        sys.stderr.write("[hexstrike-wrapper] Server already running.\n")
+
+    # 2. Launch MCP client — inherit stdin/stdout/stderr so Kiro can talk to it via stdio
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUTF8"] = "1"
+
+    mcp_args = [sys.executable, MCP_SCRIPT, "--server", server_url]
+    if args.timeout:
+        mcp_args += ["--timeout", str(args.timeout)]
+    if args.debug:
+        mcp_args += ["--debug"]
+
+    # Use subprocess.run (not os.execve) — on Windows, os.execve breaks stdio inheritance
+    result = subprocess.run(mcp_args, env=env)
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Multiple fixes to make hexstrike-ai work on Windows and resolve MCP connection issues with modern FastMCP (v3.x).

## Problems Fixed

### 1. 🪟 Windows: `/tmp` hardcoded paths → crash on startup
- `PythonEnvironmentManager`: `/tmp/hexstrike_envs` → `tempfile.gettempdir()`
- `FileOperationsManager`: `/tmp/hexstrike_files` → `tempfile.gettempdir()`
- Also fixed `bin/pip` → fallback to `Scripts/pip.exe` on Windows

### 2. ⏱️ `/health` endpoint blocking (~30s timeout)
- **Before:** 127× subprocess calls to `which <tool>` — blocked Flask thread
- **After:** `shutil.which()` (no subprocess, instant) + 60s in-memory cache
- Bonus: `which` doesn't exist on Windows, `shutil.which` is cross-platform

### 3. 🧵 Flask single-threaded → MCP timeout
- Added `threaded=True` to `app.run()`
- Prevents `/health` from blocking concurrent API requests

### 4. 🔧 Duplicate `httpx_probe` tool → FastMCP v3 crash
- FastMCP v3.x raises on duplicate `@mcp.tool()` names
- Renamed first definition to `httpx_probe_single` (single-target variant)

### 5. 🚀 Added `start_hexstrike.py` wrapper
- Auto-starts `hexstrike_server.py` if not already running
- Waits for `/health` to respond (up to 60s) before launching MCP client
- Kills stale instances on target port before starting
- Uses `subprocess.run()` instead of `os.execve` (Windows stdio inheritance fix)

## Tested on
- Windows 11, Python 3.13
- FastMCP 3.2.4, MCP SDK 1.26.0
- Kiro IDE (MCP client)

## Usage
```json
{
  "command": "python",
  "args": ["path/to/start_hexstrike.py", "--server", "http://127.0.0.1:8888"]
}
