### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,16 @@ Configure VS Code settings in `.vscode/settings.json`:
 }
 ```
 
+### Autohand Code Integration
+
+With `hexstrike_server.py` running, add the local MCP bridge from the command line:
+
+```bash
+autohand mcp add hexstrike-ai python3 /absolute/path/to/hexstrike-ai/hexstrike_mcp.py --server http://localhost:8888
+```
+
+Add `--scope project` after `add` to keep the server configuration in the current project. See [Autohand Code](https://github.com/autohandai/code-cli/) for current installation and CLI details.
+
 ---
 
 ## Features


### PR DESCRIPTION
Adds an Autohand Code setup beside the existing Claude/Cursor and VS Code client examples.

The command registers HexStrike local Python MCP bridge and points it at the already-running HTTP server on port 8888, matching the repository current two-process setup. It also includes the project-scoped option.

Verification:
- Checked the stdio bridge command against the current Autohand Code MCP CLI
- Ran git diff --check

This is a documentation-only change.