### PR TITLE
Fix: pin pycparser<3.0 to fix angr import crash on fresh installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ mitmproxy>=9.0.0,<11.0.0        # HTTP proxy (mitmproxy imports)
 pwntools>=4.10.0,<5.0.0         # Binary exploitation (from pwn import *)
 angr>=9.2.0,<10.0.0             # Binary analysis (import angr)
 bcrypt==4.0.1                   # Pin bcrypt version for passlib compatibility (fixes pwntools dependency issue)
+pycparser<3.0                   # angr's CLexer wrapper breaks on pycparser 3.0's read-only filename property
 
 # ============================================================================
 # EXTERNAL SECURITY TOOLS (150+ Tools - Install separately)


### PR DESCRIPTION
## Problem

`requirements.txt` doesn't pin `pycparser`, so any fresh `pip install -r requirements.txt` today resolves the latest `pycparser` 3.0 release. That version made `CLexer.filename` a read-only property, which breaks angr's `sim_type.py` CLexer wrapper (it assigns `self.clex.filename = ...` on import):

```
File "angr/sim_type.py", line 3149, in parse
    self.clex.filename = filename
    ^^^^^^^^^^^^^^^^^^
AttributeError: property 'filename' of 'CLexer' object has no setter
```

This reproduces on a clean venv, any OS, any supported Python version — it's not specific to the `unicorn`/CMake build issue tracked in #71 / #32, and it's not covered by the open macOS setup PRs (#189, #198, #205), which is why I'm filing it separately rather than piling onto those.

## Fix

Pin `pycparser<3.0` in `requirements.txt`, matching the existing style of the `bcrypt==4.0.1` pin just above it (also there to work around a similarly-shaped downstream breakage).

## Testing

Verified `import angr` succeeds after the pin on a clean Python 3.11 venv, and confirmed the crash reproduces without it.