### PR TITLE
fix(browseragent): match PHPSESSID in weak-session-cookie check

### DIFF
--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -13755,7 +13755,7 @@ class BrowserAgent:
             name = ck.get('name','')
             # Selenium cookie dict may lack flags; attempt JS check if not present
             # (we keep lightweight – deeper flag detection requires CDP)
-            if name.lower() in ('sessionid','phpseSSID','jsessionid') and len(ck.get('value','')) < 16:
+            if name.lower() in ('sessionid','phpsessid','jsessionid') and len(ck.get('value','')) < 16:
                 issues.append({'type':'weak_session_cookie','severity':'medium','description':f'Session cookie {name} appears short'})
         return issues
 


### PR DESCRIPTION
## Problem

`_analyze_cookies` (the passive browser-agent analysis path, `hexstrike_server.py`) flags short/weak session cookies, but the membership check can never match `PHPSESSID`:

```python
name = ck.get('name','')
if name.lower() in ('sessionid','phpseSSID','jsessionid') and len(ck.get('value','')) < 16:
    issues.append({'type':'weak_session_cookie', ...})
```

`name.lower()` is always all-lowercase, but the middle literal `'phpseSSID'` has uppercase letters, so the comparison is impossible for it. `PHPSESSID` — PHP's standard session cookie — is therefore **never** detected as weak, even though the correctly-lowercased siblings `'sessionid'` and `'jsessionid'` work. Those working siblings make the intent unambiguous: the literal should be `'phpsessid'`.

## Reproduction

Cookie `{'name': 'PHPSESSID', 'value': 'abc123'}` (value length 6 < 16):

| literal | result |
|---|---|
| `'phpseSSID'` (current) | `[]` — weak PHP session cookie missed ❌ |
| `'phpsessid'` (fixed) | one `weak_session_cookie` finding ✅ |

`SESSIONID` / `JSESSIONID` are correctly flagged either way (control).

## Fix

```python
if name.lower() in ('sessionid','phpsessid','jsessionid') and len(ck.get('value','')) < 16:
```

Verified RED→GREEN on the extracted function logic; `python -m py_compile hexstrike_server.py` passes. (No test suite exists in the repo.)
