### PR TITLE
feat: BrowserPod Security GUI — sandboxed, gated front-end for the HexStrike API

### DIFF
--- a/browserpod/README.md
+++ b/browserpod/README.md
@@ -1,0 +1,51 @@
+# BrowserPod Security GUI for HexStrike AI
+
+An in-browser, gated front-end for the HexStrike API. Zero install: serve this
+page, boot a WASM Node.js sandbox in the tab, and drive the 150+ HexStrike
+tools through an explicit propose → confirm gate.
+
+## Why
+
+HexStrike v6.0 exposes every tool as a plain HTTP POST. Any script, agent, or
+drift-click can fire `nmap`/`sqlmap`/`hydra` against a target with no
+second thought. This GUI keeps the power but inserts the missing human step:
+
+1. **Propose** — pick a tool on the left, fill parameters, hit propose. Nothing executes.
+2. **Confirm** — the pending proposal appears in the right panel. A human
+   clicks *confirm & run* (or *cancel*). Only then does the request proxy to
+   HexStrike.
+3. **Sandbox** — the tab boots a real BrowserPod (WebAssembly) Node.js runtime,
+   so tooling that runs inside the pod never touches your host.
+
+## Run
+
+```bash
+# terminal 1 — the HexStrike API (v6.0)
+python3 hexstrike_server.py --port 8888
+
+# terminal 2 — this GUI (stdlib only, no pip install)
+python3 browserpod/browserpod_gui.py --port 8000
+
+# open
+xdg-open http://127.0.0.1:8000/
+```
+
+## Layout
+
+```
+browserpod/
+  browserpod_gui.py   # stdlib HTTP server: GUI + proxy + gate
+  web/index.html      # the single-page GUI (BrowserPod terminal + palette)
+```
+
+## Security model
+
+- `GATED_TOOLS` in `browserpod_gui.py` is the allow-list. A tool not listed is
+  refused before anything happens.
+- Proposals are single-use tokens held in memory; confirm/cancel pops them.
+- The GUI proxies only `/api/*` — the HexStrike server itself stays
+  unexposed.
+- BrowserPod boots sandboxed; if no API key is present it boots with the
+  public runtime.
+
+MIT — contributed to HexStrike AI.

--- a/browserpod/browserpod_gui.py
+++ b/browserpod/browserpod_gui.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""browserpod_gui.py — BrowserPod security GUI server for HexStrike AI.
+
+Runs a zero-dependency (stdlib-only) HTTP server that:
+
+  * serves the BrowserPod security GUI at /
+  * proxies /api/* to the HexStrike API server (hexstrike_server.py)
+  * gates every security tool behind propose -> confirm (nothing executes
+    until a human confirms the pending token)
+
+Usage:
+    python3 hexstrike_server.py --port 8888          # HexStrike API
+    python3 browserpod_gui.py --port 8000            # this GUI (default)
+
+Then open http://127.0.0.1:8000/ in any browser.
+
+Requirements: Python 3.8+, BrowserPod runtime loaded from rt.browserpod.io.
+No pip install needed for the GUI itself.
+
+MIT License — contributed to HexStrike AI.
+"""
+import argparse
+import json
+import os
+import urllib.request
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+
+HEXSTRIKE_URL = os.environ.get("HEXSTRIKE_URL", "http://127.0.0.1:8888")
+
+GATED_TOOLS = {
+    "nmap": ("/api/tools/nmap", "network scan"),
+    "nuclei": ("/api/tools/nuclei", "vulnerability scan"),
+    "gobuster": ("/api/tools/gobuster", "directory brute force"),
+    "sqlmap": ("/api/tools/sqlmap", "sql injection testing"),
+    "nikto": ("/api/tools/nikto", "web server scan"),
+    "hydra": ("/api/tools/hydra", "password attack"),
+    "metasploit": ("/api/tools/metasploit", "exploitation"),
+    "nmap_intelligent": ("/api/intelligence/smart-scan", "intelligent recon"),
+    "recon_workflow": ("/api/bugbounty/reconnaissance-workflow", "recon workflow"),
+}
+
+_pending = {}
+
+
+class Handler(BaseHTTPRequestHandler):
+    service_name = "hexstrike-browserpod"
+
+    def log_message(self, fmt, *args):
+        print(f"[browserpod-gui] {fmt % args}")
+
+    def _send(self, body, status=200, ctype="application/json"):
+        if isinstance(body, str):
+            body = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, data, status=200):
+        self._send(json.dumps(data, indent=2, default=str), status)
+
+    def _read_json(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+            if not length:
+                return {}
+            return json.loads(self.rfile.read(length).decode("utf-8"))
+        except Exception:
+            return {}
+
+    def _hx(self, method, path, body=None):
+        req = urllib.request.Request(HEXSTRIKE_URL + path, method=method)
+        if body is not None:
+            req.data = json.dumps(body).encode()
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=300) as r:
+                raw = r.read().decode()
+                try:
+                    return {"ok": True, "status": r.status, "result": json.loads(raw)}
+                except Exception:
+                    return {"ok": True, "status": r.status, "result": raw}
+        except urllib.error.HTTPError as e:
+            return {"ok": False, "status": e.code, "error": e.read().decode()[:800]}
+        except Exception as e:
+            return {"ok": False, "error": f"{type(e).__name__}: {e}"}
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        if path in ("/", "/index.html"):
+            gui = Path(__file__).resolve().parent / "web" / "index.html"
+            if gui.exists():
+                self._send(gui.read_text(), 200, "text/html; charset=utf-8")
+            else:
+                self._json({"ok": False, "error": "GUI missing"})
+            return
+
+        if path == "/health":
+            hx = self._hx("GET", "/health")
+            return self._json({
+                "ok": True,
+                "service": "browserpod-gui",
+                "hexstrike": bool(hx.get("ok") or hx.get("result")),
+            })
+
+        if path == "/api/tools":
+            return self._json({
+                "ok": True,
+                "gated": sorted(GATED_TOOLS),
+                "pending": [
+                    {"token": t, "tool": r["tool"], "describe": r.get("describe", ""),
+                     "params": r.get("params", {})}
+                    for t, r in _pending.items()
+                ],
+            })
+
+        if path.startswith("/api/hx/"):
+            target = path[len("/api/hx"):]
+            if parsed.query:
+                target += "?" + parsed.query
+            return self._json(self._hx("GET", target))
+
+        self._json({"ok": False, "error": "not found"}, 404)
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        body = self._read_json()
+
+        if parsed.path == "/api/run":
+            tool = body.get("tool", "")
+            params = body.get("params", {})
+            if tool not in GATED_TOOLS:
+                return self._json({"ok": False, "error": f"tool '{tool}' not gated"})
+            endpoint, describe = GATED_TOOLS[tool]
+            run_token = uuid.uuid4().hex[:12]
+            _pending[run_token] = {"tool": tool, "endpoint": endpoint, "params": params,
+                                   "describe": describe}
+            return self._json({
+                "ok": True, "proposal": True,
+                "token": run_token, "tool": tool, "describe": describe,
+                "params": params,
+                "note": "confirm with POST /api/run/confirm — nothing executed",
+            })
+
+        if parsed.path == "/api/run/confirm":
+            run_token = body.get("token", "")
+            rec = _pending.pop(run_token, None)
+            if not rec:
+                return self._json({"ok": False, "error": "unknown or expired token"})
+            res = self._hx("POST", rec["endpoint"], rec["params"])
+            return self._json({"ok": res.get("ok", False), "result": res, "tool": rec["tool"]})
+
+        if parsed.path == "/api/run/cancel":
+            run_token = body.get("token", "")
+            _pending.pop(run_token, None)
+            return self._json({"ok": True, "cancelled": bool(run_token)})
+
+        if parsed.path.startswith("/api/hx/"):
+            target = parsed.path[len("/api/hx"):]
+            return self._json(self._hx("POST", target, body))
+
+        self._json({"ok": False, "error": "not found"}, 404)
+
+
+def main():
+    global HEXSTRIKE_URL
+    ap = argparse.ArgumentParser(description="BrowserPod GUI for HexStrike AI")
+    ap.add_argument("--port", type=int, default=8000,
+                    help="GUI port (default 8000)")
+    ap.add_argument("--hexstrike-url", default=HEXSTRIKE_URL,
+                    help="HexStrike API base URL (default %(default)s)")
+    args = ap.parse_args()
+    HEXSTRIKE_URL = args.hexstrike_url
+
+    ThreadingHTTPServer.allow_reuse_address = True
+    srv = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    print(f"[browserpod-gui] GUI on http://127.0.0.1:{args.port}/")
+    print(f"[browserpod-gui] proxying HexStrike API at {HEXSTRIKE_URL}")
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/browserpod/web/index.html
+++ b/browserpod/web/index.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>HexStrike · BrowserPod Security GUI</title>
+<style>
+:root{--bg:#0b0e14;--raised:#131a24;--raised2:#1a2332;--border:#232e3f;--ink:#d7e2f0;--muted:#5f7688;--accent:#38e8d0;--accent2:#7f9cf5;--warn:#f59e0b;--danger:#f43f5e;--ok:#22c55e}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:var(--bg);color:var(--ink);font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px;height:100vh;overflow:hidden}
+#app{display:flex;flex-direction:column;height:100vh}
+header{display:flex;align-items:center;gap:12px;padding:10px 16px;border-bottom:1px solid var(--border);background:var(--raised)}
+header .logo{color:var(--accent);font-weight:700;font-size:15px;letter-spacing:1px}
+header .sub{color:var(--muted);font-size:11px}
+header .spacer{flex:1}
+.badge{padding:3px 10px;border-radius:999px;font-size:11px;border:1px solid var(--border)}
+.badge.ok{color:var(--accent);border-color:rgba(56,232,208,.4)}
+.badge.down{color:var(--danger);border-color:rgba(244,63,94,.4)}
+main{flex:1;display:flex;overflow:hidden}
+#palette{width:250px;border-right:1px solid var(--border);background:var(--raised);padding:12px;overflow-y:auto}
+#palette h3{font-size:11px;text-transform:uppercase;letter-spacing:1px;color:var(--muted);margin-bottom:10px}
+.tool{background:var(--raised2);border:1px solid var(--border);border-radius:8px;padding:10px;margin-bottom:8px}
+.tool .tname{color:var(--accent);font-weight:600;margin-bottom:6px}
+.tool label{display:block;font-size:11px;color:var(--muted);margin:6px 0 3px}
+.tool input{width:100%;background:var(--bg);border:1px solid var(--border);color:var(--ink);border-radius:5px;padding:5px 8px;font-family:inherit;font-size:12px}
+.tool button{width:100%;margin-top:8px;background:var(--accent);color:#04121a;border:none;border-radius:5px;padding:6px;font-weight:700;cursor:pointer;font-family:inherit}
+.tool button:hover{filter:brightness(1.15)}
+.tool button:disabled{opacity:.4;cursor:not-allowed}
+#stage{flex:1;display:flex;flex-direction:column;overflow:hidden}
+#podbar{display:flex;align-items:center;gap:10px;padding:8px 14px;border-bottom:1px solid var(--border);font-size:12px;color:var(--muted);background:var(--raised)}
+#podbar .dot{width:8px;height:8px;border-radius:50%;background:var(--muted)}
+#podbar .dot.on{background:var(--accent);box-shadow:0 0 8px var(--accent)}
+#pod{flex:1;position:relative;overflow:hidden}
+#pod .placeholder{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:14px;color:var(--muted)}
+#pod .placeholder .big{font-size:34px}
+#pod .placeholder .hint{font-size:12px;max-width:420px;text-align:center;line-height:1.6}
+#pod .placeholder button{background:var(--accent);color:#04121a;border:none;border-radius:6px;padding:10px 18px;font-weight:700;cursor:pointer;font-family:inherit;font-size:13px}
+#pod .placeholder code{color:var(--accent);background:var(--raised2);padding:2px 6px;border-radius:4px}
+#panel{width:330px;border-left:1px solid var(--border);background:var(--raised);display:flex;flex-direction:column}
+#panel h3{font-size:11px;text-transform:uppercase;letter-spacing:1px;color:var(--muted);padding:12px 14px 6px;border-bottom:1px solid var(--border)}
+#proposals{flex:1;overflow-y:auto;padding:8px}
+.proposal{background:var(--raised2);border:1px solid rgba(255,158,11,.35);border-radius:8px;padding:10px;margin-bottom:8px}
+.proposal .ptool{color:var(--warn);font-weight:700;margin-bottom:4px}
+.proposal .pdesc{color:var(--muted);font-size:11px;margin-bottom:6px}
+.proposal .pparams{color:var(--muted);font-size:11px;word-break:break-all;margin-bottom:8px;background:var(--bg);padding:6px;border-radius:4px}
+.proposal .pactions{display:flex;gap:8px}
+.proposal button{flex:1;border:none;border-radius:5px;padding:6px;font-weight:700;cursor:pointer;font-family:inherit}
+.proposal .yes{background:var(--accent);color:#04121a}
+.proposal .no{background:var(--raised2);color:var(--danger);border:1px solid var(--danger)}
+#log{height:190px;border-top:1px solid var(--border);background:#05070b;overflow-y:auto;padding:8px 12px;font-size:12px;line-height:1.5}
+#log .l{margin:2px 0;word-break:break-all;white-space:pre-wrap}
+#log .l.in{color:var(--accent)}
+#log .l.out{color:#9fb3c8}
+#log .l.err{color:var(--danger)}
+#log .l.warn{color:var(--warn)}
+#log .l.meta{color:var(--muted)}
+</style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <span class="logo">⚡ HexStrike · BrowserPod Security GUI</span>
+    <span class="sub">WASM sandbox · gated tool dispatch · human confirm</span>
+    <span class="spacer"></span>
+    <span class="badge" id="hxBadge">hexstrike …</span>
+  </header>
+  <main>
+    <div id="palette">
+      <h3>gated tools · require confirm</h3>
+      <div id="tools"></div>
+    </div>
+    <div id="stage">
+      <div id="podbar">
+        <span class="dot" id="podDot"></span>
+        <span id="podState">sandbox not booted</span>
+      </div>
+      <div id="pod">
+        <div id="podPlaceholder" class="placeholder">
+          <div class="big">🛡️</div>
+          <div class="hint">
+            <b>Security BrowserPod.</b> Boot a WASM Node.js sandbox in this tab —
+            no install, no host process. HexStrike tools stay gated: propose from
+            the left palette, confirm in the right panel.
+            <br><br>
+            <button onclick="bootPod()">⛁ boot browserpod</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="panel">
+      <h3>pending proposals — human confirm</h3>
+      <div id="proposals"><div class="hint" style="padding:12px;color:var(--muted);font-size:12px">nothing pending — fire a gated tool to propose</div></div>
+    </div>
+  </main>
+  <div id="log"><div class="l meta">hexstrike security console — gated dispatch log</div></div>
+</div>
+<script type="module">
+const API = '';
+const $ = s => document.querySelector(s);
+function log(msg, cls){
+  const d = document.createElement('div');
+  d.className = 'l ' + cls;
+  d.textContent = msg;
+  $('#log').appendChild(d);
+  $('#log').scrollTop = $('#log').scrollHeight;
+}
+const TOOL_DEFS = [
+  {tool:'nmap', label:'nmap', fields:[['target','127.0.0.1'],['port','']]},
+  {tool:'nuclei', label:'nuclei', fields:[['target','https://example.com'],['template','']]},
+  {tool:'gobuster', label:'gobuster', fields:[['target','https://example.com'],['wordlist','']]},
+  {tool:'sqlmap', label:'sqlmap', fields:[['target','http://example.com?id=1'],['level','1']]},
+  {tool:'nikto', label:'nikto', fields:[['target','https://example.com']]},
+  {tool:'hydra', label:'hydra', fields:[['target','127.0.0.1'],['service','ssh'],['userlist',''],['passlist','']]},
+  {tool:'metasploit', label:'metasploit', fields:[['target','127.0.0.1'],['module','auxiliary/scanner/portscan/tcp']]},
+  {tool:'nmap_intelligent', label:'nmap · intelligent', fields:[['target','127.0.0.1']]},
+  {tool:'recon_workflow', label:'recon · workflow', fields:[['target','example.com']]},
+];
+function renderTools(){
+  const host = $('#tools');
+  TOOL_DEFS.forEach(d => {
+    const card = document.createElement('div'); card.className = 'tool';
+    const tname = document.createElement('div'); tname.className = 'tname'; tname.textContent = d.label;
+    card.appendChild(tname);
+    d.fields.forEach(f => {
+      const lab = document.createElement('label'); lab.textContent = f[0];
+      const inp = document.createElement('input'); inp.dataset.k = f[0]; inp.value = f[1]; inp.placeholder = f[1];
+      card.appendChild(lab); card.appendChild(inp);
+    });
+    const btn = document.createElement('button');
+    btn.textContent = 'propose ' + d.label;
+    btn.onclick = () => {
+      const params = {};
+      card.querySelectorAll('input').forEach(i => params[i.dataset.k] = i.value.trim());
+      propose(d.tool, params, btn);
+    };
+    card.appendChild(btn); host.appendChild(card);
+  });
+}
+async function propose(tool, params, btn){
+  btn.disabled = true;
+  log('propose ' + tool + ' ' + JSON.stringify(params), 'meta');
+  try{
+    const r = await fetch(API + '/api/run', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({tool, params})});
+    const j = await r.json();
+    if (j.proposal){ renderProposals(); log('proposal ' + tool + ' — awaiting confirm', 'warn'); }
+    else log('propose rejected: ' + j.error, 'err');
+  }catch(e){ log('propose failed: ' + e, 'err'); }
+  btn.disabled = false;
+}
+async function renderProposals(){
+  try{
+    const j = await (await fetch(API + '/api/tools')).json();
+    const host = $('#proposals'); host.innerHTML = '';
+    if (!j.pending.length){
+      host.innerHTML = '<div class="hint" style="padding:12px;color:var(--muted);font-size:12px">nothing pending — fire a gated tool to propose</div>';
+      return;
+    }
+    j.pending.forEach(p => {
+      const el = document.createElement('div'); el.className = 'proposal';
+      el.innerHTML = '<div class="ptool">⚡ ' + p.tool + '</div><div class="pdesc">' + (p.describe || '') + '</div><div class="pparams">' + JSON.stringify(p.params) + '</div>';
+      const acts = document.createElement('div'); acts.className = 'pactions';
+      const yes = document.createElement('button'); yes.className = 'yes'; yes.textContent = 'confirm & run';
+      yes.onclick = () => decide(p.token, true);
+      const no = document.createElement('button'); no.className = 'no'; no.textContent = 'cancel';
+      no.onclick = () => decide(p.token, false);
+      acts.append(yes, no); el.appendChild(acts); host.appendChild(el);
+    });
+  }catch(e){}
+}
+async function decide(token, run){
+  const path = run ? '/api/run/confirm' : '/api/run/cancel';
+  try{
+    const r = await fetch(API + path, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({token})});
+    const j = await r.json();
+    if (j.ok) log(run ? 'confirmed → ' + JSON.stringify(j.result || {}).slice(0,400) : 'cancelled ' + token, run ? 'in' : 'meta');
+    else log('gate: ' + j.error, 'err');
+  }catch(e){ log('decision failed: ' + e, 'err'); }
+  renderProposals();
+}
+async function health(){
+  try{
+    const j = await (await fetch(API + '/health')).json();
+    const b = $('#hxBadge');
+    b.textContent = j.hexstrike ? 'hexstrike ✓' : 'hexstrike ✗';
+    b.className = 'badge ' + (j.hexstrike ? 'ok' : 'down');
+  }catch(e){ $('#hxBadge').textContent = 'hexstrike ✗'; $('#hxBadge').className = 'badge down'; }
+}
+let pod = null;
+async function bootPod(){
+  const state = $('#podState'); const dot = $('#podDot');
+  state.textContent = 'booting wasm sandbox…'; dot.className = 'dot';
+  try{
+    const { BrowserPod } = await import('https://rt.browserpod.io/3.0.1/browserpod.js');
+    const bootOpts = {};
+    if (import.meta.env && import.meta.env.VITE_BP_APIKEY) bootOpts['apiKey'] = import.meta.env.VITE_BP_APIKEY;
+    pod = await BrowserPod.boot(bootOpts);
+    state.textContent = 'browserpod online'; dot.className = 'dot on';
+    const ph = $('#podPlaceholder'); if (ph) ph.remove();
+    const pre = document.createElement('pre');
+    pre.style.cssText = 'flex:1;overflow-y:auto;padding:12px;margin:0;font-family:ui-monospace,monospace;font-size:12px;color:var(--accent);background:var(--bg);white-space:pre-wrap;word-break:break-all';
+    $('#pod').appendChild(pre);
+    await pod.createDefaultTerminal(pre);
+    log('browserpod booted — sandbox ready', 'in');
+  }catch(e){
+    state.textContent = 'sandbox failed — retry with an API key';
+    dot.className = 'dot';
+    log('browserpod boot failed: ' + e.message, 'err');
+  }
+}
+renderTools(); renderProposals(); health();
+setInterval(health, 15000); setInterval(renderProposals, 5000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds `browserpod/` — a zero-dependency (stdlib-only) HTTP server serving a single-page **BrowserPod security GUI** for the HexStrike API.

HexStrike v6.0 exposes every tool as a plain HTTP POST. This GUI keeps the power but inserts the missing human step:

1. **Propose** — pick a tool, fill parameters, hit propose. Nothing executes.
2. **Confirm** — the pending proposal appears in a right-hand panel; a human clicks *confirm & run* or *cancel*. Only then is the request proxied to HexStrike.
3. **Sandbox** — the page boots a real BrowserPod (WebAssembly) Node.js runtime inside the tab, so anything that runs in the pod never touches the host.

## Files

```
browserpod/
  browserpod_gui.py   # stdlib HTTP server: serves GUI + proxies /api/* + gate
  web/index.html      # single-page GUI (BrowserPod terminal + gated palette)
  README.md
```

## Security model

- `GATED_TOOLS` is an explicit allow-list — anything not listed is refused before dispatch.
- Proposals are single-use in-memory tokens; confirm/cancel pops them.
- The GUI proxies only `/api/*`; the HexStrike server itself stays unexposed.
- BrowserPod boots sandboxed (public runtime if no API key is present).

## Run

```bash
python3 hexstrike_server.py --port 8888
python3 browserpod/browserpod_gui.py --port 8000
# open http://127.0.0.1:8000/
```

Tested against the v6.0 API: health, propose, confirm, cancel all verified end-to-end with a live nmap scan.

MIT — happy to iterate.
