### PR TITLE
Make server bind host configurable and improve MCP client defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Local backup files
+*.bak
+*.bak-*
+
+# Log files
+*.log
+
+# Local office / scratch documents
+*.odt
+
+# Personal launcher scripts (contain machine-specific paths)
+start_hexstrike_server.sh
+start_hexstrike_mcp.sh

--- a/hexstrike_mcp.py
+++ b/hexstrike_mcp.py
@@ -141,7 +141,7 @@ logger = logging.getLogger(__name__)
 
 # Default configuration
 DEFAULT_HEXSTRIKE_SERVER = "http://127.0.0.1:8888"  # Default HexStrike server URL
-DEFAULT_REQUEST_TIMEOUT = 300  # 5 minutes default timeout for API requests
+DEFAULT_REQUEST_TIMEOUT = 1800  # 30 minutes - allow time for large/long-running scans
 MAX_RETRIES = 3  # Maximum number of retries for connection attempts
 
 class HexStrikeClient:
@@ -5416,12 +5416,16 @@ def setup_mcp_server(hexstrike_client: HexStrikeClient) -> FastMCP:
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="Run the HexStrike AI MCP Client")
-    parser.add_argument("--server", type=str, default=DEFAULT_HEXSTRIKE_SERVER,
+    parser.add_argument("--server", type=str, nargs="?", const=DEFAULT_HEXSTRIKE_SERVER,
+                      default=DEFAULT_HEXSTRIKE_SERVER,
                       help=f"HexStrike AI API server URL (default: {DEFAULT_HEXSTRIKE_SERVER})")
     parser.add_argument("--timeout", type=int, default=DEFAULT_REQUEST_TIMEOUT,
                       help=f"Request timeout in seconds (default: {DEFAULT_REQUEST_TIMEOUT})")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if not args.server:
+        args.server = DEFAULT_HEXSTRIKE_SERVER
+    return args
 
 def main():
     """Main entry point for the MCP server."""

--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -17286,4 +17286,4 @@ if __name__ == "__main__":
         if line.strip():
             logger.info(line)
 
-    app.run(host="0.0.0.0", port=API_PORT, debug=DEBUG_MODE)
+    app.run(host=API_HOST, port=API_PORT, debug=DEBUG_MODE)


### PR DESCRIPTION
## What changed

**Server (`hexstrike_server.py`)**
- `app.run()` now binds to `API_HOST` (from the `HEXSTRIKE_HOST` env var, default `127.0.0.1`) instead of a hardcoded `0.0.0.0`.

**MCP client (`hexstrike_mcp.py`)**
- Raised `DEFAULT_REQUEST_TIMEOUT` from 300s to 1800s (30 min) so long-running scans don't time out.
- `--server` now accepts an optional value (`nargs="?"`/`const`) and falls back to the default server URL when it resolves empty.

## Why
- Binding to `127.0.0.1` by default is safer than exposing the server on all interfaces (`0.0.0.0`) out of the box, while still allowing `HEXSTRIKE_HOST=0.0.0.0` for network access when explicitly desired. It also matches the startup banner, which already reported `API_HOST` while the actual bind used `0.0.0.0`.
- Large scans routinely exceed the old 5-minute client timeout.
- Making `--server` tolerant of a bare/empty flag avoids a crash and keeps the documented default.

## Reviewer notes
- No new dependencies; changes are limited to config defaults and argument parsing.
- Behavior change: users who relied on the implicit `0.0.0.0` bind must now set `HEXSTRIKE_HOST=0.0.0.0` to expose the server on all interfaces.
