### PR TITLE
Fix command injection in nmap/gobuster target parameters

### DIFF
--- a/command_injection_poc_test.py
+++ b/command_injection_poc_test.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.argv = ["hexstrike_server.py"]
+
+import hexstrike_server
+
+
+class TestNmapCommandInjection(unittest.TestCase):
+    """The /api/tools/nmap and /api/tools/gobuster endpoints build a
+    shell=True command by string interpolation. Before the fix, the
+    client-supplied target/url/ports/wordlist parameters were interpolated
+    with no escaping, so a target like '127.0.0.1; touch /tmp/x #' ran the
+    appended command. safe_shell_arg() (shlex.quote) now wraps those values.
+    """
+
+    def setUp(self):
+        self.marker_path = os.path.join(tempfile.gettempdir(), "hexstrike_poc_marker")
+        if os.path.exists(self.marker_path):
+            os.remove(self.marker_path)
+        self.client = hexstrike_server.app.test_client()
+
+    def tearDown(self):
+        if os.path.exists(self.marker_path):
+            os.remove(self.marker_path)
+
+    def _marker_created(self, timeout=5):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if os.path.exists(self.marker_path):
+                return True
+            time.sleep(0.1)
+        return False
+
+    def test_nmap_target_injection_blocked(self):
+        injected_target = f"127.0.0.1; touch {self.marker_path} #"
+        resp = self.client.post(
+            "/api/tools/nmap",
+            json={"target": injected_target, "scan_type": "-sn", "use_recovery": False},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(
+            self._marker_created(timeout=2),
+            "shell metacharacters in 'target' must not execute as a separate command",
+        )
+
+    def test_gobuster_url_injection_blocked(self):
+        injected_url = f"http://127.0.0.1; touch {self.marker_path} #"
+        resp = self.client.post(
+            "/api/tools/gobuster",
+            json={"url": injected_url, "mode": "dir", "use_recovery": False},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(
+            self._marker_created(timeout=2),
+            "shell metacharacters in 'url' must not execute as a separate command",
+        )
+
+    def test_nmap_legitimate_target_still_scans(self):
+        resp = self.client.post(
+            "/api/tools/nmap",
+            json={"target": "127.0.0.1", "scan_type": "-sn", "use_recovery": False},
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertTrue(body.get("success"), f"legitimate scan should still succeed: {body}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hexstrike_server.py
+++ b/hexstrike_server.py
@@ -22,6 +22,7 @@ import argparse
 import json
 import logging
 import os
+import shlex
 import subprocess
 import sys
 import traceback
@@ -10324,6 +10325,20 @@ def create_comprehensive_bugbounty_assessment():
 # SECURITY TOOLS API ENDPOINTS
 # ============================================================================
 
+def safe_shell_arg(value: str) -> str:
+    """Quote a single client-supplied value (target, URL, port list, wordlist
+    path, ...) for safe interpolation into a shell=True command string.
+
+    These endpoints build a command line by string interpolation rather than
+    passing an argv list to subprocess, so every value that isn't a fixed
+    flag chosen by this code must go through shlex.quote() before it reaches
+    the string. This does not cover an 'additional_args' style parameter
+    that is meant to carry multiple space-separated flags; that class of
+    parameter needs its own flag allowlist, not quoting, since quoting the
+    whole string would just pass it through as one broken argument.
+    """
+    return shlex.quote(str(value))
+
 @app.route("/api/tools/nmap", methods=["POST"])
 def nmap():
     """Execute nmap scan with enhanced logging, caching, and intelligent error handling"""
@@ -10344,12 +10359,12 @@ def nmap():
         command = f"nmap {scan_type}"
 
         if ports:
-            command += f" -p {ports}"
+            command += f" -p {safe_shell_arg(ports)}"
 
         if additional_args:
             command += f" {additional_args}"
 
-        command += f" {target}"
+        command += f" {safe_shell_arg(target)}"
 
         logger.info(f"🔍 Starting Nmap scan: {target}")
 
@@ -10398,7 +10413,7 @@ def gobuster():
                 "error": f"Invalid mode: {mode}. Must be one of: dir, dns, fuzz, vhost"
             }), 400
 
-        command = f"gobuster {mode} -u {url} -w {wordlist}"
+        command = f"gobuster {mode} -u {safe_shell_arg(url)} -w {safe_shell_arg(wordlist)}"
 
         if additional_args:
             command += f" {additional_args}"


### PR DESCRIPTION
Fixes the command injection reported in #263.

## Summary

`/api/tools/nmap` and `/api/tools/gobuster` built their shell command by f-string interpolation of client-supplied JSON fields (`target`, `url`, `ports`, `wordlist`), then ran it via `subprocess.Popen(command, shell=True, ...)`. None of those fields was quoted, so a value containing shell metacharacters ran as a separate command. Combined with the server binding `0.0.0.0` with no authentication anywhere in the code, this was unauthenticated remote code execution for anyone who could reach the API port.

## Fix

Added `safe_shell_arg()` (`shlex.quote()`) and applied it to the client-controlled single-value fields in both endpoints. New tests in `command_injection_poc_test.py` confirm the injection is blocked on both endpoints after the fix, and that a legitimate scan still runs.

## Scope

The same f-string-into-`shell=True` pattern is present in the other `/api/tools/*` endpoints in this file (90 total via `@app.route("/api/tools/`), not just these two. This PR is scoped to the two demonstrated in #263; the rest need the same treatment with `safe_shell_arg`. `additional_args`-style fields (multiple space-separated CLI flags) need a flag allowlist instead of quoting, also not covered here. Adding authentication in front of the API is worth considering independently of this fix.